### PR TITLE
RUST_BACKTRACE=full and use namespaces instead of buildjet

### DIFF
--- a/.github/workflows/rtc-node.yml
+++ b/.github/workflows/rtc-node.yml
@@ -94,7 +94,7 @@ jobs:
             platform: linux
             target: x86_64-unknown-linux-gnu
             build_image: quay.io/pypa/manylinux_2_28_x86_64
-          - os: buildjet-4vcpu-ubuntu-2204-arm
+          - os: namespace-profile-default-arm64
             platform: linux
             target: aarch64-unknown-linux-gnu
             build_image: quay.io/pypa/manylinux_2_28_aarch64
@@ -102,7 +102,7 @@ jobs:
     name: stable - ${{ matrix.target }} - node@20
     runs-on: ${{ matrix.os }}
     env:
-      RUST_BACKTRACE: 1
+      RUST_BACKTRACE: full
     needs: lint
     steps:
       - uses: actions/checkout@v4
@@ -145,7 +145,7 @@ jobs:
           docker run --rm -v $PWD:/workspace -w /workspace ${{ matrix.build_image }} bash -c "\
             uname -a; \
             export PATH=/root/.cargo/bin:\$PATH; \
-            export RUST_BACKTRACE=1; \
+            export RUST_BACKTRACE=full; \
             yum install openssl-devel libX11-devel mesa-libGL-devel libXext-devel clang-devel -y; \
             curl --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y; \
             curl -fsSL https://rpm.nodesource.com/setup_20.x | bash -; \


### PR DESCRIPTION
it's been the fourth time that buildjet has been down...