### PR TITLE
Infer pnpm version from package.json in CI

### DIFF
--- a/.github/workflows/rtc-node.yml
+++ b/.github/workflows/rtc-node.yml
@@ -31,7 +31,7 @@ jobs:
 
       - uses: pnpm/action-setup@v2
         with:
-          version: 9
+          version: 9.2.0
 
       - name: Use Node.js 20
         uses: actions/setup-node@v4

--- a/.github/workflows/rtc-node.yml
+++ b/.github/workflows/rtc-node.yml
@@ -30,8 +30,6 @@ jobs:
       - uses: actions/checkout@v4
 
       - uses: pnpm/action-setup@v2
-        with:
-          version: 9.2.0
 
       - name: Use Node.js 20
         uses: actions/setup-node@v4


### PR DESCRIPTION
otherwise the pnpm action complains about multiple version definitions. 
turborepo v2 requires the packageManager field to be set in the root package.json