### PR TITLE
Remove ignored packages from changeset

### DIFF
--- a/.changeset/metal-icons-change.md
+++ b/.changeset/metal-icons-change.md
@@ -1,5 +1,4 @@
 ---
-"example-publish-wav": patch
 "@livekit/rtc-node": minor
 ---
 

--- a/.changeset/rotten-stingrays-refuse.md
+++ b/.changeset/rotten-stingrays-refuse.md
@@ -1,0 +1,5 @@
+---
+'livekit-server-sdk': patch
+---
+
+Adds missing await to startParticipantEgress #221


### PR DESCRIPTION
as the example is treated as an ignored package (we don't release it to npm as a package), we also don't want to add it to the changeset here. CI runs are failing because of that.
If the CLI showed it as a "changed package" (?) then this might be bug in the changesets CLI.