### PR TITLE
Adds missing await to startParticipantEgress

### DIFF
--- a/packages/livekit-server-sdk/src/EgressClient.ts
+++ b/packages/livekit-server-sdk/src/EgressClient.ts
@@ -282,7 +282,7 @@ export class EgressClient extends ServiceBase {
       svc,
       'StartParticipantEgress',
       req,
-      this.authHeader({ roomRecord: true }),
+      await this.authHeader({ roomRecord: true }),
     );
     return EgressInfo.fromJson(data, { ignoreUnknownFields: true });
   }


### PR DESCRIPTION
Using the `startParticipantEgress` method on the EgressClient always returns a 401 because the auth header's not actually being set, due to a missing `await`.

Confirmed this was the issue by trying the same request with the livekit-cli which was capable of starting a participant egress without issue.