### PR TITLE
livekit-rtc: set room state to disconnected on dc

### DIFF
--- a/packages/livekit-rtc/src/room.ts
+++ b/packages/livekit-rtc/src/room.ts
@@ -159,6 +159,7 @@ export class Room extends (EventEmitter as new () => TypedEmitter<RoomCallbacks>
 
     FfiClient.instance.removeAllListeners();
     this.removeAllListeners();
+    this.connectionState = ConnectionState.CONN_DISCONNECTED;
   }
 
   private onFfiEvent = (ffiEvent: FfiEvent) => {


### PR DESCRIPTION
while trying to reproduce another bug i found this: `room.disconnect()` does not set the room state to disconnected.