### PR TITLE
Fix ms conversion bug in AudioSource

### DIFF
--- a/.changeset/fast-bees-sin.md
+++ b/.changeset/fast-bees-sin.md
@@ -1,0 +1,5 @@
+---
+"@livekit/rtc-node": patch
+---
+
+Fix ms conversion bug in AudioSource

--- a/packages/livekit-rtc/src/audio_source.ts
+++ b/packages/livekit-rtc/src/audio_source.ts
@@ -103,7 +103,8 @@ export class AudioSource {
   async captureFrame(frame: AudioFrame) {
     const now = Number(process.hrtime.bigint() / 1000000n);
     const elapsed = this.lastCapture === 0 ? 0 : now - this.lastCapture;
-    this.currentQueueSize += (frame.samplesPerChannel / frame.sampleRate - elapsed) * 1000;
+    const frameDurationMs = (frame.samplesPerChannel / frame.sampleRate) * 1000;
+    this.currentQueueSize += frameDurationMs - elapsed;
 
     this.lastCapture = now;
 


### PR DESCRIPTION
`elapsed` is in millis, so it was doing `(seconds - milliseconds) * 1000` which meant currentQueueSize was typically recorded as being negative millions of millis and thus the timer for waitForPlayout would always resolve immediately.