### PR TITLE
feat(rtc-node): expose VideoCodec

### DIFF
--- a/.changeset/gentle-bikes-sell.md
+++ b/.changeset/gentle-bikes-sell.md
@@ -1,0 +1,5 @@
+---
+"@livekit/rtc-node": patch
+---
+
+expose VideoCodec

--- a/packages/livekit-rtc/src/index.ts
+++ b/packages/livekit-rtc/src/index.ts
@@ -39,6 +39,6 @@ export {
 } from './proto/room_pb.js';
 export { EncryptionType, EncryptionState } from './proto/e2ee_pb.js';
 export { StreamState, TrackKind, TrackSource } from './proto/track_pb.js';
-export { VideoBufferType, VideoRotation } from './proto/video_frame_pb.js';
+export { VideoBufferType, VideoRotation, VideoCodec } from './proto/video_frame_pb.js';
 export { ParticipantKind } from './proto/participant_pb.js';
 export { dispose } from './ffi_client.js';


### PR DESCRIPTION
this enum is used in `TrackPublishOptions`.