### PR TITLE
RPC updates

### DIFF
--- a/.changeset/sharp-ads-push.md
+++ b/.changeset/sharp-ads-push.md
@@ -1,0 +1,6 @@
+---
+"example-rpc": patch
+"@livekit/rtc-node": patch
+---
+
+Rename responseTimeoutMs to responseTimeout, other RPC updates

--- a/examples/rpc/index.ts
+++ b/examples/rpc/index.ts
@@ -1,4 +1,4 @@
-import { Room, RpcError } from '@livekit/rtc-node';
+import { Room, RpcError, type RpcInvocationData } from '@livekit/rtc-node';
 import { randomBytes } from 'crypto';
 import { config } from 'dotenv';
 import { AccessToken } from 'livekit-server-sdk';
@@ -63,15 +63,8 @@ async function main() {
 const registerReceiverMethods = (greetersRoom: Room, mathGeniusRoom: Room) => {
   greetersRoom.localParticipant?.registerRpcMethod(
     'arrival',
-    async (
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      requestId: string,
-      callerIdentity: string,
-      payload: string,
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      responseTimeout: number,
-    ) => {
-      console.log(`[Greeter] Oh ${callerIdentity} arrived and said "${payload}"`);
+    async (data: RpcInvocationData) => {
+      console.log(`[Greeter] Oh ${data.callerIdentity} arrived and said "${data.payload}"`);
       await new Promise((resolve) => setTimeout(resolve, 2000));
       return 'Welcome and have a wonderful day!';
     },
@@ -79,17 +72,11 @@ const registerReceiverMethods = (greetersRoom: Room, mathGeniusRoom: Room) => {
 
   mathGeniusRoom.localParticipant?.registerRpcMethod(
     'square-root',
-    async (
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      requestId: string,
-      callerIdentity: string,
-      payload: string,
-      responseTimeout: number,
-    ) => {
-      const jsonData = JSON.parse(payload);
+    async (data: RpcInvocationData) => {
+      const jsonData = JSON.parse(data.payload);
       const number = jsonData.number;
       console.log(
-        `[Math Genius] I guess ${callerIdentity} wants the square root of ${number}. I've only got ${responseTimeout / 1000} seconds to respond but I think I can pull it off.`,
+        `[Math Genius] I guess ${data.callerIdentity} wants the square root of ${number}. I've only got ${data.responseTimeout / 1000} seconds to respond but I think I can pull it off.`,
       );
 
       console.log(`[Math Genius] *doing math*…`);
@@ -103,18 +90,11 @@ const registerReceiverMethods = (greetersRoom: Room, mathGeniusRoom: Room) => {
 
   mathGeniusRoom.localParticipant?.registerRpcMethod(
     'divide',
-    async (
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      requestId: string,
-      callerIdentity: string,
-      payload: string,
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      responseTimeout: number,
-    ) => {
-      const jsonData = JSON.parse(payload);
+    async (data: RpcInvocationData) => {
+      const jsonData = JSON.parse(data.payload);
       const { numerator, denominator } = jsonData;
       console.log(
-        `[Math Genius] ${callerIdentity} wants to divide ${numerator} by ${denominator}. This could be interesting...`,
+        `[Math Genius] ${data.callerIdentity} wants to divide ${numerator} by ${denominator}. This could be interesting...`,
       );
 
       if (denominator === 0) {
@@ -132,7 +112,11 @@ const registerReceiverMethods = (greetersRoom: Room, mathGeniusRoom: Room) => {
 const performGreeting = async (room: Room): Promise<void> => {
   console.log("[Caller] Letting the greeter know that I've arrived");
   try {
-    const response = await room.localParticipant!.performRpc('greeter', 'arrival', 'Hello');
+    const response = await room.localParticipant!.performRpc({
+      destinationIdentity: 'greeter',
+      method: 'arrival',
+      payload: 'Hello',
+    });
     console.log(`[Caller] That's nice, the greeter said: "${response}"`);
   } catch (error) {
     console.error('[Caller] RPC call failed:', error);
@@ -143,11 +127,11 @@ const performGreeting = async (room: Room): Promise<void> => {
 const performSquareRoot = async (room: Room): Promise<void> => {
   console.log("[Caller] What's the square root of 16?");
   try {
-    const response = await room.localParticipant!.performRpc(
-      'math-genius',
-      'square-root',
-      JSON.stringify({ number: 16 }),
-    );
+    const response = await room.localParticipant!.performRpc({
+      destinationIdentity: 'math-genius',
+      method: 'square-root',
+      payload: JSON.stringify({ number: 16 }),
+    });
     const parsedResponse = JSON.parse(response);
     console.log(`[Caller] Nice, the answer was ${parsedResponse.result}`);
   } catch (error) {
@@ -159,11 +143,11 @@ const performSquareRoot = async (room: Room): Promise<void> => {
 const performQuantumHypergeometricSeries = async (room: Room): Promise<void> => {
   console.log("[Caller] What's the quantum hypergeometric series of 42?");
   try {
-    const response = await room.localParticipant!.performRpc(
-      'math-genius',
-      'quantum-hypergeometric-series',
-      JSON.stringify({ number: 42 }),
-    );
+    const response = await room.localParticipant!.performRpc({
+      destinationIdentity: 'math-genius',
+      method: 'quantum-hypergeometric-series',
+      payload: JSON.stringify({ number: 42 }),
+    });
     const parsedResponse = JSON.parse(response);
     console.log(`[Caller] genius says ${parsedResponse.result}!`);
   } catch (error) {
@@ -182,11 +166,11 @@ const performQuantumHypergeometricSeries = async (room: Room): Promise<void> => 
 const performDivision = async (room: Room): Promise<void> => {
   console.log("[Caller] Let's try dividing 10 by 0");
   try {
-    const response = await room.localParticipant!.performRpc(
-      'math-genius',
-      'divide',
-      JSON.stringify({ numerator: 10, denominator: 0 }),
-    );
+    const response = await room.localParticipant!.performRpc({
+      destinationIdentity: 'math-genius',
+      method: 'divide',
+      payload: JSON.stringify({ numerator: 10, denominator: 0 }),
+    });
     const parsedResponse = JSON.parse(response);
     console.log(`[Caller] The result is ${parsedResponse.result}`);
   } catch (error) {

--- a/examples/rpc/index.ts
+++ b/examples/rpc/index.ts
@@ -69,7 +69,7 @@ const registerReceiverMethods = (greetersRoom: Room, mathGeniusRoom: Room) => {
       callerIdentity: string,
       payload: string,
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      responseTimeoutMs: number,
+      responseTimeout: number,
     ) => {
       console.log(`[Greeter] Oh ${callerIdentity} arrived and said "${payload}"`);
       await new Promise((resolve) => setTimeout(resolve, 2000));
@@ -84,12 +84,12 @@ const registerReceiverMethods = (greetersRoom: Room, mathGeniusRoom: Room) => {
       requestId: string,
       callerIdentity: string,
       payload: string,
-      responseTimeoutMs: number,
+      responseTimeout: number,
     ) => {
       const jsonData = JSON.parse(payload);
       const number = jsonData.number;
       console.log(
-        `[Math Genius] I guess ${callerIdentity} wants the square root of ${number}. I've only got ${responseTimeoutMs / 1000} seconds to respond but I think I can pull it off.`,
+        `[Math Genius] I guess ${callerIdentity} wants the square root of ${number}. I've only got ${responseTimeout / 1000} seconds to respond but I think I can pull it off.`,
       );
 
       console.log(`[Math Genius] *doing math*…`);
@@ -109,7 +109,7 @@ const registerReceiverMethods = (greetersRoom: Room, mathGeniusRoom: Room) => {
       callerIdentity: string,
       payload: string,
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      responseTimeoutMs: number,
+      responseTimeout: number,
     ) => {
       const jsonData = JSON.parse(payload);
       const { numerator, denominator } = jsonData;

--- a/packages/livekit-rtc/README.md
+++ b/packages/livekit-rtc/README.md
@@ -92,14 +92,14 @@ room.localParticipant?.registerRpcMethod(
   'greet',
 
   // method handler - will be called when the method is invoked by a RemoteParticipant
-  async (requestId: string, callerIdentity: string, payload: string, responseTimeoutMs: number) => {
+  async (requestId: string, callerIdentity: string, payload: string, responseTimeout: number) => {
     console.log(`Received greeting from ${caller.identity}: ${payload}`);
     return `Hello, ${caller.identity}!`;
   }
 );
 ```
 
-In addition to the payload, your handler will also receive `responseTimeoutMs`, which informs you the maximum time available to return a response. If you are unable to respond in time, the call will result in an error on the caller's side.
+In addition to the payload, your handler will also receive `responseTimeout`, which informs you the maximum time available to return a response. If you are unable to respond in time, the call will result in an error on the caller's side.
 
 #### Performing an RPC request
 
@@ -118,7 +118,7 @@ try {
 }
 ```
 
-You may find it useful to adjust the `responseTimeoutMs` parameter, which indicates the amount of time you will wait for a response. We recommend keeping this value as low as possible while still satisfying the constraints of your application.
+You may find it useful to adjust the `responseTimeout` parameter, which indicates the amount of time you will wait for a response. We recommend keeping this value as low as possible while still satisfying the constraints of your application.
 
 #### Errors
 

--- a/packages/livekit-rtc/README.md
+++ b/packages/livekit-rtc/README.md
@@ -92,9 +92,9 @@ room.localParticipant?.registerRpcMethod(
   'greet',
 
   // method handler - will be called when the method is invoked by a RemoteParticipant
-  async (requestId: string, callerIdentity: string, payload: string, responseTimeout: number) => {
-    console.log(`Received greeting from ${caller.identity}: ${payload}`);
-    return `Hello, ${caller.identity}!`;
+  async (data: RpcInvocationData) => {
+    console.log(`Received greeting from ${data.callerIdentity}: ${data.payload}`);
+    return `Hello, ${data.callerIdentity}!`;
   }
 );
 ```
@@ -107,11 +107,11 @@ The caller may then initiate an RPC call like so:
 
 ```typescript
 try {
-  const response = await room.localParticipant!.performRpc(
-    'recipient-identity',
-    'greet',
-    'Hello from RPC!'
-  );
+  const response = await room.localParticipant!.performRpc({
+    destinationIdentity: 'recipient-identity',
+    method: 'greet',
+    payload: 'Hello from RPC!',
+  });
   console.log('RPC response:', response);
 } catch (error) {
   console.error('RPC call failed:', error);

--- a/packages/livekit-rtc/src/index.ts
+++ b/packages/livekit-rtc/src/index.ts
@@ -49,7 +49,7 @@ export {
   ContinualGatheringPolicy,
   ConnectionState,
 } from './proto/room_pb.js';
-export { RpcError } from './rpc.js';
+export { RpcError, type RpcInvocationData, type PerformRpcParams } from './rpc.js';
 export { EncryptionType, EncryptionState } from './proto/e2ee_pb.js';
 export { StreamState, TrackKind, TrackSource } from './proto/track_pb.js';
 export { VideoBufferType, VideoRotation, VideoCodec } from './proto/video_frame_pb.js';

--- a/packages/livekit-rtc/src/participant.ts
+++ b/packages/livekit-rtc/src/participant.ts
@@ -121,7 +121,7 @@ export class LocalParticipant extends Participant {
       requestId: string,
       callerIdentity: string,
       payload: string,
-      responseTimeoutMs: number,
+      responseTimeout: number,
     ) => Promise<string>
   > = new Map();
 
@@ -379,7 +379,7 @@ export class LocalParticipant extends Participant {
    * @param destinationIdentity - The `identity` of the destination participant
    * @param method - The method name to call
    * @param payload - The method payload
-   * @param responseTimeoutMs - Timeout for receiving a response after initial connection
+   * @param responseTimeout - Timeout for receiving a response after initial connection (milliseconds)
    * @returns A promise that resolves with the response payload or rejects with an error.
    * @throws Error on failure. Details in `message`.
    */
@@ -387,14 +387,14 @@ export class LocalParticipant extends Participant {
     destinationIdentity: string,
     method: string,
     payload: string,
-    responseTimeoutMs?: number,
+    responseTimeout?: number,
   ): Promise<string> {
     const req = create(PerformRpcRequestSchema, {
       localParticipantHandle: this.ffi_handle.handle,
       destinationIdentity,
       method,
       payload,
-      responseTimeoutMs,
+      responseTimeoutMs: responseTimeout,
     });
 
     const res = FfiClient.instance.request<PerformRpcResponse>({
@@ -424,7 +424,7 @@ export class LocalParticipant extends Participant {
    * ```typescript
    * room.localParticipant?.registerRpcMethod(
    *   'greet',
-   *   async (requestId: string, callerIdentity: string, payload: string, responseTimeoutMs: number) => {
+   *   async (requestId: string, callerIdentity: string, payload: string, responseTimeout: number) => {
    *     console.log(`Received greeting from ${callerIdentity}: ${payload}`);
    *     return `Hello, ${callerIdentity}!`;
    *   }
@@ -435,10 +435,10 @@ export class LocalParticipant extends Participant {
    * - `requestId`: A unique identifier for this RPC request
    * - `callerIdentity`: The identity of the RemoteParticipant who initiated the RPC call
    * - `payload`: The data sent by the caller (as a string)
-   * - `responseTimeoutMs`: The maximum time available to return a response
+   * - `responseTimeout`: The maximum time available to return a response (milliseconds)
    *
    * The handler should return a Promise that resolves to a string.
-   * If unable to respond within `responseTimeoutMs`, the request will result in an error on the caller's side.
+   * If unable to respond within `responseTimeout`, the request will result in an error on the caller's side.
    *
    * You may throw errors of type `RpcError` with a string `message` in the handler,
    * and they will be received on the caller's side with the message intact.
@@ -450,7 +450,7 @@ export class LocalParticipant extends Participant {
       requestId: string,
       callerIdentity: string,
       payload: string,
-      responseTimeoutMs: number,
+      responseTimeout: number,
     ) => Promise<string>,
   ) {
     this.rpcHandlers.set(method, handler);
@@ -490,7 +490,7 @@ export class LocalParticipant extends Participant {
     requestId: string,
     callerIdentity: string,
     payload: string,
-    responseTimeoutMs: number,
+    responseTimeout: number,
   ) {
     let responseError: RpcError | null = null;
     let responsePayload: string | null = null;
@@ -501,7 +501,7 @@ export class LocalParticipant extends Participant {
       responseError = RpcError.builtIn('UNSUPPORTED_METHOD');
     } else {
       try {
-        responsePayload = await handler(requestId, callerIdentity, payload, responseTimeoutMs);
+        responsePayload = await handler(requestId, callerIdentity, payload, responseTimeout);
       } catch (error) {
         if (error instanceof RpcError) {
           responseError = error;

--- a/packages/livekit-rtc/src/participant.ts
+++ b/packages/livekit-rtc/src/participant.ts
@@ -52,7 +52,7 @@ import type {
   RpcMethodInvocationResponseResponse,
   UnregisterRpcMethodResponse,
 } from './proto/rpc_pb.js';
-import { RpcError, type PerformRpcParams, type RpcInvocationData } from './rpc.js';
+import { type PerformRpcParams, RpcError, type RpcInvocationData } from './rpc.js';
 import type { LocalTrack } from './track.js';
 import type { RemoteTrackPublication, TrackPublication } from './track_publication.js';
 import { LocalTrackPublication } from './track_publication.js';

--- a/packages/livekit-rtc/src/rpc.ts
+++ b/packages/livekit-rtc/src/rpc.ts
@@ -40,7 +40,6 @@ export interface RpcInvocationData {
   responseTimeout: number;
 }
 
-
 /**
  * Specialized error handling for RPC methods.
  *

--- a/packages/livekit-rtc/src/rpc.ts
+++ b/packages/livekit-rtc/src/rpc.ts
@@ -3,6 +3,44 @@
 // SPDX-License-Identifier: Apache-2.0
 import type { RpcError as RpcError_Proto } from './proto/rpc_pb.js';
 
+/** Parameters for initiating an RPC call */
+export interface PerformRpcParams {
+  /** The `identity` of the destination participant */
+  destinationIdentity: string;
+  /** The method name to call */
+  method: string;
+  /** The method payload */
+  payload: string;
+  /** Timeout for receiving a response after initial connection (milliseconds). Default: 10000 */
+  responseTimeout?: number;
+}
+
+/**
+ * Data passed to method handler for incoming RPC invocations
+ */
+export interface RpcInvocationData {
+  /**
+   * The unique request ID. Will match at both sides of the call, useful for debugging or logging.
+   */
+  requestId: string;
+
+  /**
+   * The unique participant identity of the caller.
+   */
+  callerIdentity: string;
+
+  /**
+   * The payload of the request. User-definable format, typically JSON.
+   */
+  payload: string;
+
+  /**
+   * The maximum time the caller will wait for a response.
+   */
+  responseTimeout: number;
+}
+
+
 /**
  * Specialized error handling for RPC methods.
  *


### PR DESCRIPTION
- remove ms from response timeout param  name to align with platform conventions
- use an interface for params to performRpc to improve param name clarity
- bundle invocation args into a data class to provide flexibility for adding more args in the future without breaking existing code