### PR TITLE
remove example-rpc from changeset

### DIFF
--- a/.changeset/itchy-cheetahs-taste.md
+++ b/.changeset/itchy-cheetahs-taste.md
@@ -1,5 +1,4 @@
 ---
-"example-rpc": minor
 "@livekit/rtc-node": minor
 ---
 

--- a/.changeset/sharp-ads-push.md
+++ b/.changeset/sharp-ads-push.md
@@ -1,5 +1,4 @@
 ---
-"example-rpc": patch
 "@livekit/rtc-node": patch
 ---
 


### PR DESCRIPTION
Not sure why it auto-generated these since its in the ignore list but it doesn't like having them in here