### PR TITLE
fixed imports in AgentDispatchClient.js

### DIFF
--- a/packages/livekit-server-sdk/src/AgentDispatchClient.ts
+++ b/packages/livekit-server-sdk/src/AgentDispatchClient.ts
@@ -8,8 +8,8 @@ import {
   ListAgentDispatchRequest,
   ListAgentDispatchResponse,
 } from '@livekit/protocol';
-import ServiceBase from './ServiceBase';
-import { type Rpc, TwirpRpc, livekitPackage } from './TwirpRPC';
+import ServiceBase from './ServiceBase.js';
+import { type Rpc, TwirpRpc, livekitPackage } from './TwirpRPC.js';
 
 interface CreateDispatchOptions {
   // any custom data to send along with the job.


### PR DESCRIPTION
![Screenshot 2024-11-08 at 3 20 59 PM](https://github.com/user-attachments/assets/42d382ff-de79-4f1e-b7f4-8749932a1c99)

File path: livekit-server-sdk/dist/AgentDispatchClient.js

Why: seems to miss .js extension in the imports leading to build issues hence making this PR leading to build issue as shown in the attachment

Fix: I've added the .js extension in imports mentioned below:
```
import ServiceBase from './ServiceBase';
import { TwirpRpc, livekitPackage } from './TwirpRPC';
```