### PR TITLE
Add missing createSIPParticipant params

### DIFF
--- a/.changeset/early-forks-sin.md
+++ b/.changeset/early-forks-sin.md
@@ -1,0 +1,5 @@
+---
+'livekit-server-sdk': minor
+---
+
+SIP: Add missing params in CreateSIPParticipant

--- a/packages/livekit-server-sdk/src/SipClient.ts
+++ b/packages/livekit-server-sdk/src/SipClient.ts
@@ -423,9 +423,9 @@ export class SipClient extends ServiceBase {
     let playRingtone: boolean = false;
     let playDialtone: boolean = false;
     let hidePhoneNumber: boolean = false;
-    let ringingTimeout: number = 0;
-    let maxCallDuration: number = 0;
-    let enableKrisp: boolean = false;
+    let ringingTimeout: number | undefined = undefined;
+    let maxCallDuration: number | undefined = undefined;
+    let enableKrisp: boolean | undefined = undefined;
 
     if (opts !== undefined) {
       participantIdentity = opts.participantIdentity || '';
@@ -435,9 +435,9 @@ export class SipClient extends ServiceBase {
       playRingtone = opts.playRingtone || false;
       playDialtone = opts.playDialtone || playRingtone; // Enable PlayDialtone if either PlayDialtone or playRingtone is set
       hidePhoneNumber = opts.hidePhoneNumber || false;
-      ringingTimeout = opts.ringingTimeout || 0;
-      maxCallDuration = opts.maxCallDuration || 0;
-      enableKrisp = opts.enableKrisp || false;
+      ringingTimeout = opts.ringingTimeout || undefined;
+      maxCallDuration = opts.maxCallDuration || undefined;
+      enableKrisp = opts.enableKrisp || undefined;
     }
 
     const req = new CreateSIPParticipantRequest({
@@ -451,8 +451,8 @@ export class SipClient extends ServiceBase {
       playRingtone: playDialtone,
       playDialtone: playDialtone,
       hidePhoneNumber: hidePhoneNumber,
-      ringingTimeout: new Duration({ seconds: BigInt(ringingTimeout) }),
-      maxCallDuration: new Duration({ seconds: BigInt(maxCallDuration) }),
+      ringingTimeout: ringingTimeout ? new Duration({ seconds: BigInt(ringingTimeout) }) : undefined,
+      maxCallDuration: maxCallDuration ? new Duration({ seconds: BigInt(maxCallDuration) }) : undefined,
       enableKrisp: enableKrisp,
     }).toJson();
 

--- a/packages/livekit-server-sdk/src/SipClient.ts
+++ b/packages/livekit-server-sdk/src/SipClient.ts
@@ -451,8 +451,12 @@ export class SipClient extends ServiceBase {
       playRingtone: playDialtone,
       playDialtone: playDialtone,
       hidePhoneNumber: hidePhoneNumber,
-      ringingTimeout: ringingTimeout ? new Duration({ seconds: BigInt(ringingTimeout) }) : undefined,
-      maxCallDuration: maxCallDuration ? new Duration({ seconds: BigInt(maxCallDuration) }) : undefined,
+      ringingTimeout: ringingTimeout
+        ? new Duration({ seconds: BigInt(ringingTimeout) })
+        : undefined,
+      maxCallDuration: maxCallDuration
+        ? new Duration({ seconds: BigInt(maxCallDuration) })
+        : undefined,
       enableKrisp: enableKrisp,
     }).toJson();
 

--- a/packages/livekit-server-sdk/src/SipClient.ts
+++ b/packages/livekit-server-sdk/src/SipClient.ts
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: 2024 LiveKit, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
+import { Duration } from '@bufbuild/protobuf';
 import {
   CreateSIPDispatchRuleRequest,
   CreateSIPInboundTrunkRequest,
@@ -31,7 +32,6 @@ import {
 import ServiceBase from './ServiceBase.js';
 import type { Rpc } from './TwirpRPC.js';
 import { TwirpRpc, livekitPackage } from './TwirpRPC.js';
-import { Duration } from '@bufbuild/protobuf';
 
 const svc = 'SIP';
 

--- a/packages/livekit-server-sdk/src/SipClient.ts
+++ b/packages/livekit-server-sdk/src/SipClient.ts
@@ -31,6 +31,7 @@ import {
 import ServiceBase from './ServiceBase.js';
 import type { Rpc } from './TwirpRPC.js';
 import { TwirpRpc, livekitPackage } from './TwirpRPC.js';
+import { Duration } from '@bufbuild/protobuf';
 
 const svc = 'SIP';
 
@@ -94,6 +95,9 @@ export interface CreateSipParticipantOptions {
   playRingtone?: boolean; // Deprecated, use playDialtone instead
   playDialtone?: boolean;
   hidePhoneNumber?: boolean;
+  ringingTimeout?: number; // Duration in seconds
+  maxCallDuration?: number; // Duration in seconds
+  enableKrisp?: boolean;
 }
 
 export interface TransferSipParticipantOptions {
@@ -419,6 +423,9 @@ export class SipClient extends ServiceBase {
     let playRingtone: boolean = false;
     let playDialtone: boolean = false;
     let hidePhoneNumber: boolean = false;
+    let ringingTimeout: number = 0;
+    let maxCallDuration: number = 0;
+    let enableKrisp: boolean = false;
 
     if (opts !== undefined) {
       participantIdentity = opts.participantIdentity || '';
@@ -428,6 +435,9 @@ export class SipClient extends ServiceBase {
       playRingtone = opts.playRingtone || false;
       playDialtone = opts.playDialtone || playRingtone; // Enable PlayDialtone if either PlayDialtone or playRingtone is set
       hidePhoneNumber = opts.hidePhoneNumber || false;
+      ringingTimeout = opts.ringingTimeout || 0;
+      maxCallDuration = opts.maxCallDuration || 0;
+      enableKrisp = opts.enableKrisp || false;
     }
 
     const req = new CreateSIPParticipantRequest({
@@ -441,6 +451,9 @@ export class SipClient extends ServiceBase {
       playRingtone: playDialtone,
       playDialtone: playDialtone,
       hidePhoneNumber: hidePhoneNumber,
+      ringingTimeout: new Duration({ seconds: BigInt(ringingTimeout) }),
+      maxCallDuration: new Duration({ seconds: BigInt(maxCallDuration) }),
+      enableKrisp: enableKrisp,
     }).toJson();
 
     const data = await this.rpc.request(


### PR DESCRIPTION
The following params exist in the Go SDK but not in the node SDK:

```
- RingingTimeout
- MaxCallDuration
- EnableKrisp
```

They were added last month to the protocol: https://github.com/livekit/protocol/commit/19b686d3128927e025eb9d5258c636cc0de3e790

Tested in my local project to work correctly.