### PR TITLE
Fix publint INVALID_REPOSITORY_VALUE warning

### DIFF
--- a/packages/livekit-server-sdk/package.json
+++ b/packages/livekit-server-sdk/package.json
@@ -5,7 +5,10 @@
   "main": "dist/index.js",
   "require": "dist/index.cjs",
   "types": "dist/index.d.ts",
-  "repository": "git@github.com:livekit/server-sdk-js.git",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/livekit/server-sdk-js.git"
+  },
   "author": "David Zhao <david@davidzhao.com>",
   "license": "Apache-2.0",
   "type": "module",


### PR DESCRIPTION
From https://publint.dev/livekit-server-sdk@2.9.3:

![grafik](https://github.com/user-attachments/assets/aa5b1583-1179-44fc-a7d5-5761aa46d351)

Fixed by applying the best practice outlined here: https://publint.dev/rules#invalid_repository_value