### PR TITLE
Fix CJS package masquerading as ESM on import

### DIFF
--- a/packages/livekit-server-sdk/package.json
+++ b/packages/livekit-server-sdk/package.json
@@ -20,7 +20,7 @@
     "src"
   ],
   "scripts": {
-    "build": "tsup --onSuccess \"tsc --declaration --emitDeclarationOnly\"",
+    "build": "tsup --onSuccess \"tsc --declaration --emitDeclarationOnly && cp ./dist/index.d.ts ./dist/index.d.cts\"",
     "build:watch": "tsc --watch",
     "build-docs": "typedoc",
     "changeset": "changeset",

--- a/packages/livekit-server-sdk/package.json
+++ b/packages/livekit-server-sdk/package.json
@@ -11,7 +11,6 @@
   "type": "module",
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
       "require": "./dist/index.cjs"
     }


### PR DESCRIPTION
May fix #357

How to generate the required `.d.cts` using tsup or tsc went over the top of my head, however `npx publint` advised that it would suffice to duplicate the `.d.ts` file for that (see commit message of b5d562a2f14ba13d2eff4fe6c7eff9872c7de804 for a detailed explanation).

