### PR TITLE
Fix screenshare option not being applied to participant egress

### DIFF
--- a/.changeset/real-roses-remember.md
+++ b/.changeset/real-roses-remember.md
@@ -1,0 +1,5 @@
+---
+'livekit-server-sdk': patch
+---
+
+Fix screenshare option not being applied to participant egress

--- a/packages/livekit-server-sdk/src/EgressClient.ts
+++ b/packages/livekit-server-sdk/src/EgressClient.ts
@@ -274,6 +274,7 @@ export class EgressClient extends ServiceBase {
     const req = new ParticipantEgressRequest({
       roomName,
       identity,
+      screenShare: opts?.screenShare ?? false,
       options,
       fileOutputs,
       streamOutputs,


### PR DESCRIPTION
The screenShare option on ParticipantEgressOptions is not being passed through to the ParticipantEgressRequest, so it's never applied when initiating the egress.  This is preventing screenshare recordings when using participant egress.