### PR TITLE
Fix cjs usage

### DIFF
--- a/.changeset/healthy-pots-design.md
+++ b/.changeset/healthy-pots-design.md
@@ -1,0 +1,5 @@
+---
+"livekit-server-sdk": patch
+---
+
+Fix cjs usage of WebhookReceiver

--- a/packages/livekit-server-sdk/src/WebhookReceiver.ts
+++ b/packages/livekit-server-sdk/src/WebhookReceiver.ts
@@ -4,7 +4,7 @@
 import type { BinaryReadOptions, JsonReadOptions, JsonValue } from '@bufbuild/protobuf';
 import { WebhookEvent as ProtoWebhookEvent } from '@livekit/protocol';
 import { TokenVerifier } from './AccessToken.js';
-import digest from './digest.js';
+import { digest } from './digest.js';
 
 export const authorizeHeader = 'Authorize';
 

--- a/packages/livekit-server-sdk/src/digest.ts
+++ b/packages/livekit-server-sdk/src/digest.ts
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 // Use the Web Crypto API if available, otherwise fallback to Node.js crypto
-export default async function digest(data: string): Promise<ArrayBuffer> {
+export async function digest(data: string): Promise<ArrayBuffer> {
   if (globalThis.crypto?.subtle) {
     const encoder = new TextEncoder();
     return crypto.subtle.digest('SHA-256', encoder.encode(data));


### PR DESCRIPTION
closes #381

For some reason the default export gets wrongly marked as ESM for CJS. Converting the import to a named import changes the output in dist to 
```
var import_protocol = require("@livekit/protocol");
var import_AccessToken = require("./AccessToken.cjs");
var import_digest = require("./digest.cjs");
```