### PR TITLE
Improve error insight for twirp related requests

### DIFF
--- a/.changeset/gentle-panthers-guess.md
+++ b/.changeset/gentle-panthers-guess.md
@@ -1,0 +1,5 @@
+---
+"livekit-server-sdk": minor
+---
+
+Improve error insight for twirp related requests, changes the error signature to custom TwirpError

--- a/packages/livekit-server-sdk/src/TwirpRPC.ts
+++ b/packages/livekit-server-sdk/src/TwirpRPC.ts
@@ -14,12 +14,12 @@ export interface Rpc {
 }
 
 export class TwirpError extends Error {
-  statusCode: number;
+  status: number;
 
-  constructor(statusCode: number, name: string, message: string) {
+  constructor(status: number, name: string, message: string) {
     super(message);
     this.name = name;
-    this.statusCode = statusCode;
+    this.status = status;
   }
 }
 


### PR DESCRIPTION
example errors with this PR:

parsing string directly from body (non standard twirp error response). 
Using a wrong secret key:
```
Unauthorized: invalid token: eyJhbGciOiJIUzI1NiJ9.xxxxx.LXnIYsbn6clLx0sixhWnGh-v0SI82Teb656awscYvGc, error: go-jose/go-jose: error in cryptographic primitive
    at TwirpRpc.request (./livekit-server-sdk/dist/TwirpRPC.js:46:13)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async RoomServiceClient.createRoom (./livekit-server-sdk/dist/RoomServiceClient.js:40:18)
    at async request (./examples/webhooks-http/webhook.js:32:18) {
  status: 401,
  code: undefined
}
```

parsing json from body (standard twirp error response).
Using unsupported values:
```
Bad Request: the json request could not be decoded
    at TwirpRpc.request (./livekit-server-sdk/dist/TwirpRPC.js:51:13)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async RoomServiceClient.createRoom (./livekit-server-sdk/dist/RoomServiceClient.js:40:18)
    at async request (./examples/webhooks-http/webhook.js:32:18) {
  status: 400,
  code: 'malformed'
}
```



