### PR TITLE
Fix RPC invocation and room sid update

### DIFF
--- a/.changeset/curvy-lobsters-draw.md
+++ b/.changeset/curvy-lobsters-draw.md
@@ -1,0 +1,5 @@
+---
+"@livekit/rtc-node": patch
+---
+
+Fix RPC invocation and room sid update


### PR DESCRIPTION
closes #392

As part of #368 a bunch of stuff in room.ts got removed that shouldn't have gotten removed. 

I guess this was overlooked because the diff of `room.ts` was so large that it was hidden in GH's diff-viewer and it was inconveniently placed right after all the automated _pb.js protobuf diffs. 

I manually went through the diff again and tried to catch all code that was deleted by mistake. 
@nbsp would be great if you could take a look at the diff in #368  as well to make sure I didn't miss anything.

