### PR TITLE
Expose sipNumber when creating an Sip Participant

### DIFF
--- a/packages/livekit-server-sdk/src/SipClient.ts
+++ b/packages/livekit-server-sdk/src/SipClient.ts
@@ -124,6 +124,7 @@ export interface CreateSipParticipantOptions {
   ringingTimeout?: number; // Duration in seconds
   maxCallDuration?: number; // Duration in seconds
   enableKrisp?: boolean;
+  sipNumber?: string; // Optional SIP From number to use. If empty, trunk number is used.
 }
 
 export interface TransferSipParticipantOptions {
@@ -423,6 +424,7 @@ export class SipClient extends ServiceBase {
     const req = new CreateSIPParticipantRequest({
       sipTrunkId: sipTrunkId,
       sipCallTo: number,
+      sipNumber: opts.sipNumber,
       roomName: roomName,
       participantIdentity: opts.participantIdentity || 'sip-participant',
       participantName: opts.participantName,


### PR DESCRIPTION
This allows you to define the sipNumber (=fromNumber) when placing an outbound call.

This is required when dealing with outbound trunks where multiple numbers are configured.