### PR TITLE
Use macos-15 runner images

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,11 +99,11 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: macos-latest-large
+          - os: macos-15-large
             platform: macos
             target: x86_64-apple-darwin
             macosx_deployment_target: '10.15'
-          - os: macos-latest
+          - os: macos-15
             platform: macos
             target: aarch64-apple-darwin
             macosx_deployment_target: '11.0'


### PR DESCRIPTION
macos-latest breaks the CI (as does macos-14). Currently only the `macos-15` image seems to pass. 

See https://github.com/actions/runner-images/issues/11574