### PR TITLE
fix(rtc): never panic on invalid handle

### DIFF
--- a/packages/livekit-rtc/src/nodejs.rs
+++ b/packages/livekit-rtc/src/nodejs.rs
@@ -52,12 +52,13 @@ fn livekit_ffi_request(data: Uint8Array) -> Result<Uint8Array> {
         }
     };
 
-    let res = match server::requests::handle_request(&FFI_SERVER, res) {
+    let res = match server::requests::handle_request(&FFI_SERVER, res.clone()) {
         Ok(res) => res,
         Err(err) => {
             return Err(Error::from_reason(format!(
-                "failed to handle request: {}",
-                err.to_string()
+                "failed to handle request: {} ({:?})",
+                err.to_string(),
+                res
             )));
         }
     }


### PR DESCRIPTION
old panic message:

```
thread '<unnamed>' panicked at src/nodejs.rs:55:13:
failed to handle request: invalid request: handle not found
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
fatal runtime error: failed to initiate panic, error 5
```

new error message, catchable by the node.js process:

```
file:///Users/nbsp/src/node-sdks/packages/livekit-rtc/dist/ffi_client.js:37
    const res_data = livekitFfiRequest(req_data);
                     ^

Error: failed to handle request: invalid request: handle not found
    at FfiClient.request (file:///Users/nbsp/src/node-sdks/packages/livekit-rtc/dist/ffi_client.js:37:22)
    at LocalAudioTrack.createAudioTrack (file:///Users/nbsp/src/node-sdks/packages/livekit-rtc/dist/track.js:38:36)
    at file:///Users/nbsp/src/node-sdks/examples/publish-wav/dist/index.js:31:31 {
  code: 'GenericFailure'
}
```