### PR TITLE
[feat:webhooks] Add support for customizing JWT clock tolerance for webhook verification

### DIFF
--- a/.changeset/red-rice-bow.md
+++ b/.changeset/red-rice-bow.md
@@ -1,0 +1,5 @@
+---
+'livekit-server-sdk': patch
+---
+
+chore: Add a clock tolerance parameter to support clock skew for webhooks

--- a/packages/livekit-server-sdk/src/AccessToken.ts
+++ b/packages/livekit-server-sdk/src/AccessToken.ts
@@ -9,6 +9,8 @@ import { claimsToJwtPayload } from './grants.js';
 // 6 hours
 const defaultTTL = `6h`;
 
+const defaultClockToleranceSeconds = 10;
+
 export interface AccessTokenOptions {
   /**
    * amount of time before expiration
@@ -199,9 +201,9 @@ export class TokenVerifier {
     this.apiSecret = apiSecret;
   }
 
-  async verify(token: string): Promise<ClaimGrants> {
+  async verify(token: string, clockTolerance: string | number = defaultClockToleranceSeconds): Promise<ClaimGrants> {
     const secret = new TextEncoder().encode(this.apiSecret);
-    const { payload } = await jose.jwtVerify(token, secret, { issuer: this.apiKey });
+    const { payload } = await jose.jwtVerify(token, secret, { issuer: this.apiKey, clockTolerance });
     if (!payload) {
       throw Error('invalid token');
     }

--- a/packages/livekit-server-sdk/src/AccessToken.ts
+++ b/packages/livekit-server-sdk/src/AccessToken.ts
@@ -201,9 +201,15 @@ export class TokenVerifier {
     this.apiSecret = apiSecret;
   }
 
-  async verify(token: string, clockTolerance: string | number = defaultClockToleranceSeconds): Promise<ClaimGrants> {
+  async verify(
+    token: string,
+    clockTolerance: string | number = defaultClockToleranceSeconds,
+  ): Promise<ClaimGrants> {
     const secret = new TextEncoder().encode(this.apiSecret);
-    const { payload } = await jose.jwtVerify(token, secret, { issuer: this.apiKey, clockTolerance });
+    const { payload } = await jose.jwtVerify(token, secret, {
+      issuer: this.apiKey,
+      clockTolerance,
+    });
     if (!payload) {
       throw Error('invalid token');
     }

--- a/packages/livekit-server-sdk/src/WebhookReceiver.ts
+++ b/packages/livekit-server-sdk/src/WebhookReceiver.ts
@@ -53,19 +53,21 @@ export class WebhookReceiver {
    * @param body - string of the posted body
    * @param authHeader - `Authorization` header from the request
    * @param skipAuth - true to skip auth validation
-   * @returns
+   * @param clockTolerance - How much tolerance to allow for checks against the auth header to be skewed from the claims
+   * @returns The processed webhook event
    */
   async receive(
     body: string,
     authHeader?: string,
     skipAuth: boolean = false,
+    clockTolerance?: string | number,
   ): Promise<WebhookEvent> {
     // verify token
     if (!skipAuth) {
       if (!authHeader) {
         throw new Error('authorization header is empty');
       }
-      const claims = await this.verifier.verify(authHeader);
+      const claims = await this.verifier.verify(authHeader, clockTolerance);
       // confirm sha
       const hash = await digest(body);
       const hashDecoded = btoa(


### PR DESCRIPTION
This PR adds a parameter to webhook reception (and access token verification) to support Jose's clock tolerance parameter for environments which may be slow or have other clock skew issues. 