### PR TITLE
Allow sender identity to be passed in streamText method

### DIFF
--- a/.changeset/breezy-dryers-cover.md
+++ b/.changeset/breezy-dryers-cover.md
@@ -1,0 +1,5 @@
+---
+"@livekit/rtc-node": patch
+---
+
+Allow sender identity to be passed in streamText method

--- a/packages/livekit-rtc/src/participant.ts
+++ b/packages/livekit-rtc/src/participant.ts
@@ -257,8 +257,9 @@ export class LocalParticipant extends Participant {
     attributes?: Record<string, string>;
     destinationIdentities?: Array<string>;
     streamId?: string;
+    senderIdentity?: string;
   }): Promise<TextStreamWriter> {
-    const senderIdentity = this.identity;
+    const senderIdentity = options?.senderIdentity ?? this.identity;
     const streamId = options?.streamId ?? crypto.randomUUID();
     const destinationIdentities = options?.destinationIdentities;
 


### PR DESCRIPTION
needed for stream based transcription support with sender identity overrides by agent