### PR TITLE
Fix Video Stream Memory Leak

### DIFF
--- a/.changeset/slow-games-share.md
+++ b/.changeset/slow-games-share.md
@@ -1,0 +1,5 @@
+---
+'@livekit/rtc-node': minor
+---
+
+Bugfix with memory leak in VideoStream and AudioStream

--- a/packages/livekit-rtc/src/audio_stream.ts
+++ b/packages/livekit-rtc/src/audio_stream.ts
@@ -64,6 +64,7 @@ export class AudioStream implements AsyncIterableIterator<AudioFrame> {
         const frame = AudioFrame.fromOwnedInfo(streamEvent.value.frame!);
         if (this.queueResolve) {
           this.queueResolve({ done: false, value: frame });
+          this.queueResolve = null;
         } else {
           this.eventQueue.push(frame);
         }

--- a/packages/livekit-rtc/src/video_stream.ts
+++ b/packages/livekit-rtc/src/video_stream.ts
@@ -78,6 +78,7 @@ export class VideoStream implements AsyncIterableIterator<VideoFrameEvent> {
               rotation: value.rotation!,
             },
           });
+          this.queueResolve = null;
         } else {
           this.eventQueue.push({
             frame: value.frame,


### PR DESCRIPTION
## Issue
A memory leak was identified in the `VideoStream` (and `AudioStream`) class where the Promise resolver for the async iterator was not being properly reset after use. This occurred in the `onEvent` method when processing incoming video frames from the LiveKit server. When a frame is received and a queueResolve function exists (indicating a waiting iterator consumer), the resolver was being called but the reference was not cleared afterward. If a new Frame arrives before we call `next()`, we call resolver on the stale reference learning to:
1. A memory leak.
2. A bug where frames coming in faster than calls to `next()` are not actually being stored in the queue. There being tossed into a stale resolver.

We can solve this by just simply clearing the reference to the resolver after it is called. 

## Testing
Wrote a test script that consume video from a LK server. 
 - Before fix: `2210MB` usage after 2 mins
 - After fix: `818MB` usage after 2 mins