### PR TITLE
Clean up FFI handle when streaming VideoFrames

### DIFF
--- a/.changeset/violet-actors-join.md
+++ b/.changeset/violet-actors-join.md
@@ -1,0 +1,5 @@
+---
+'@livekit/rtc-node': patch
+---
+
+Fix memory leak with FFI Handle on VideoFrame creation

--- a/packages/livekit-rtc/src/video_frame.ts
+++ b/packages/livekit-rtc/src/video_frame.ts
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2024 LiveKit, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
-import { FfiClient, FfiRequest } from './ffi_client.js';
+import { FfiClient, FfiHandle, FfiRequest } from './ffi_client.js';
 import type { OwnedVideoBuffer, VideoConvertResponse } from './proto/video_frame_pb.js';
 import {
   VideoBufferInfo,
@@ -58,7 +58,7 @@ export class VideoFrame {
   /** @internal */
   static fromOwnedInfo(owned: OwnedVideoBuffer): VideoFrame {
     const info = owned.info!;
-    return new VideoFrame(
+    const frame = new VideoFrame(
       FfiClient.instance.copyBuffer(
         info.dataPtr!,
         getPlaneLength(info.type!, info.width!, info.height!),
@@ -67,6 +67,9 @@ export class VideoFrame {
       info.height!,
       info.type!,
     );
+    // Dispose of the handle to prevent memory leaks
+    new FfiHandle(owned.handle!.id!).dispose();
+    return frame;
   }
 
   getPlane(planeNth: number): Uint8Array | void {


### PR DESCRIPTION
We need to clean up the FFIHandle after we copy over the frame data intro Node.

Memory usage before fix - `1700MB` after 2.5 mins,
Memory usage after fix - `~310MB` after 2.5 mins. 
