### PR TITLE
Remove timeout and empty frame processing in Audio Source

### DIFF
--- a/.changeset/shiny-flies-cough.md
+++ b/.changeset/shiny-flies-cough.md
@@ -1,0 +1,5 @@
+---
+'@livekit/rtc-node': patch
+---
+
+bugfix: no more negative timeouts being set on AudioSource

--- a/packages/livekit-rtc/src/audio_source.ts
+++ b/packages/livekit-rtc/src/audio_source.ts
@@ -106,6 +106,11 @@ export class AudioSource {
     if (this.closed) {
       throw new Error('AudioSource is closed');
     }
+    
+    if (frame.samplesPerChannel === 0) {
+      return;
+    }
+    
     const now = Number(process.hrtime.bigint() / BigInt(1000000));
     const elapsed = this.lastCapture === 0 ? 0 : now - this.lastCapture;
     const frameDurationMs = (frame.samplesPerChannel / frame.sampleRate) * 1000;
@@ -119,7 +124,7 @@ export class AudioSource {
 
     // remove 50ms to account for processing time
     // (e.g. using wait_for_playout for very small chunks)
-    this.timeout = setTimeout(this.release, this.currentQueueSize - 50);
+    this.timeout = setTimeout(this.release, this.currentQueueSize);
 
     const req = new CaptureAudioFrameRequest({
       sourceHandle: this.ffiHandle.handle,

--- a/packages/livekit-rtc/src/audio_source.ts
+++ b/packages/livekit-rtc/src/audio_source.ts
@@ -107,11 +107,11 @@ export class AudioSource {
     if (this.closed) {
       throw new Error('AudioSource is closed');
     }
-    
+
     if (frame.samplesPerChannel === 0) {
       return;
     }
-    
+
     const now = Number(process.hrtime.bigint() / BigInt(1000000));
     const elapsed = this.lastCapture === 0 ? 0 : now - this.lastCapture;
     const frameDurationMs = (frame.samplesPerChannel / frame.sampleRate) * 1000;

--- a/packages/livekit-rtc/src/audio_source.ts
+++ b/packages/livekit-rtc/src/audio_source.ts
@@ -99,6 +99,7 @@ export class AudioSource {
       this.lastCapture = 0;
       this.currentQueueSize = 0;
       this.promise = this.newPromise();
+      this.timeout = undefined;
     });
   }
 
@@ -122,8 +123,6 @@ export class AudioSource {
       clearTimeout(this.timeout);
     }
 
-    // remove 50ms to account for processing time
-    // (e.g. using wait_for_playout for very small chunks)
     this.timeout = setTimeout(this.release, this.currentQueueSize);
 
     const req = new CaptureAudioFrameRequest({


### PR DESCRIPTION
Port over [fix wait_for_playout finishing too early](https://github.com/livekit/python-sdks/pull/270) and [Ignore Empty Frames](https://github.com/livekit/python-sdks/pull/280)