### PR TITLE
fix bun reload

### DIFF
--- a/.changeset/violet-students-sin.md
+++ b/.changeset/violet-students-sin.md
@@ -1,0 +1,5 @@
+---
+'@livekit/rtc-node': patch
+---
+
+fix issue with bun hot reload

--- a/packages/livekit-rtc/src/ffi_client.ts
+++ b/packages/livekit-rtc/src/ffi_client.ts
@@ -25,13 +25,18 @@ export enum FfiClientEvent {
   FfiEvent = 'ffi_event',
 }
 
+declare global {
+  // eslint-disable-next-line no-var
+  var _ffiClientInstance: FfiClient | undefined;
+}
+
 export class FfiClient extends (EventEmitter as new () => TypedEmitter<FfiClientCallbacks>) {
   /** @internal */
   static get instance(): FfiClient {
-    if (!(globalThis as any)._ffiClientInstance) {
-      (globalThis as any)._ffiClientInstance = new FfiClient();
+    if (!globalThis._ffiClientInstance) {
+      globalThis._ffiClientInstance = new FfiClient();
     }
-    return (globalThis as any)._ffiClientInstance;
+    return globalThis._ffiClientInstance;
   }
 
   constructor() {

--- a/packages/livekit-rtc/src/ffi_client.ts
+++ b/packages/livekit-rtc/src/ffi_client.ts
@@ -25,14 +25,17 @@ export enum FfiClientEvent {
   FfiEvent = 'ffi_event',
 }
 
-export class FfiClient extends (EventEmitter as new () => TypedEmitter<FfiClientCallbacks>) {
-  static _client?: FfiClient;
+declare global {
+  var _ffiClientInstance: FfiClient | undefined;
+}
 
+export class FfiClient extends (EventEmitter as new () => TypedEmitter<FfiClientCallbacks>) {
   /** @internal */
   static get instance(): FfiClient {
-    if (!FfiClient._client) FfiClient._client = new FfiClient();
-
-    return FfiClient._client;
+    if (!globalThis._ffiClientInstance) {
+      globalThis._ffiClientInstance = new FfiClient();
+    }
+    return globalThis._ffiClientInstance;
   }
 
   constructor() {

--- a/packages/livekit-rtc/src/ffi_client.ts
+++ b/packages/livekit-rtc/src/ffi_client.ts
@@ -25,17 +25,13 @@ export enum FfiClientEvent {
   FfiEvent = 'ffi_event',
 }
 
-declare global {
-  var _ffiClientInstance: FfiClient | undefined;
-}
-
 export class FfiClient extends (EventEmitter as new () => TypedEmitter<FfiClientCallbacks>) {
   /** @internal */
   static get instance(): FfiClient {
-    if (!globalThis._ffiClientInstance) {
-      globalThis._ffiClientInstance = new FfiClient();
+    if (!(globalThis as any)._ffiClientInstance) {
+      (globalThis as any)._ffiClientInstance = new FfiClient();
     }
-    return globalThis._ffiClientInstance;
+    return (globalThis as any)._ffiClientInstance;
   }
 
   constructor() {


### PR DESCRIPTION
from https://bun.sh/docs/runtime/hot#hot-mode

> Starting from the entrypoint (server.ts in the example above), Bun builds a registry of all imported source files (excluding those in node_modules) and watches them for changes. When a change is detected, Bun performs a "soft reload". All files are re-evaluated, but all global state (notably, the globalThis object) is persisted.