### PR TITLE
don't use ignore array for changesets

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -8,7 +8,7 @@
   ],
   "commit": false,
   "fixed": [["@livekit/rtc-node", "@livekit/rtc-node-*"]],
-  "ignore": ["example-*"],
+  "ignore": [],
   "linked": [],
   "access": "public",
   "baseBranch": "main",


### PR DESCRIPTION
quick follow up for #498 to adhere to the changeset suggestions of using `ignore` only temporarily and let `private: true` dictate publishing