### PR TITLE
Adding the inference grant

### DIFF
--- a/packages/livekit-server-sdk/src/AccessToken.ts
+++ b/packages/livekit-server-sdk/src/AccessToken.ts
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import type { RoomConfiguration } from '@livekit/protocol';
 import * as jose from 'jose';
-import type { ClaimGrants, SIPGrant, VideoGrant } from './grants.js';
+import type { ClaimGrants, InferenceGrant, SIPGrant, VideoGrant } from './grants.js';
 import { claimsToJwtPayload } from './grants.js';
 
 // 6 hours
@@ -100,6 +100,14 @@ export class AccessToken {
    */
   addGrant(grant: VideoGrant) {
     this.grants.video = { ...(this.grants.video ?? {}), ...grant };
+  }
+
+  /**
+   * Adds an inference grant to this token.
+   * @param grant -
+   */
+  addInferenceGrant(grant: InferenceGrant) {
+    this.grants.inference = { ...(this.grants.inference ?? {}), ...grant };
   }
 
   /**

--- a/packages/livekit-server-sdk/src/grants.ts
+++ b/packages/livekit-server-sdk/src/grants.ts
@@ -103,11 +103,17 @@ export interface SIPGrant {
   call?: boolean;
 }
 
+export interface InferenceGrant {
+  /** perform inference */
+  perform?: boolean;
+}
+
 /** @internal */
 export interface ClaimGrants extends JWTPayload {
   name?: string;
   video?: VideoGrant;
   sip?: SIPGrant;
+  inference?: InferenceGrant;
   kind?: string;
   metadata?: string;
   attributes?: Record<string, string>;


### PR DESCRIPTION
The `InferenceGrant` is required to perform LLM inference in the backend. This will be used by the agents SDK.