### PR TITLE
feat(server-sdk): expose ingress `enabled` option on createIngress/updateIngress

### DIFF
--- a/.changeset/ingress-enabled-option.md
+++ b/.changeset/ingress-enabled-option.md
@@ -1,0 +1,5 @@
+---
+'livekit-server-sdk': patch
+---
+
+Add `enabled` option to `createIngress` and `updateIngress`. Setting `enabled: false` lets you disable an ingress session (reject new connection attempts) without deleting it, so the stream key is preserved. The field already exists on the protobuf `CreateIngressRequest`/`UpdateIngressRequest`; this exposes it through the typed `CreateIngressOptions`/`UpdateIngressOptions`.

--- a/packages/livekit-server-sdk/src/IngressClient.ts
+++ b/packages/livekit-server-sdk/src/IngressClient.ts
@@ -53,6 +53,11 @@ export interface CreateIngressOptions {
    */
   url?: string;
   /**
+   * whether the ingress is enabled. When set to false, new connection attempts are rejected
+   * while the stream key is preserved. The default is true.
+   */
+  enabled?: boolean;
+  /**
    * custom audio encoding parameters. optional
    */
   audio?: IngressAudioOptions;
@@ -93,6 +98,11 @@ export interface UpdateIngressOptions {
    * Transcoding is required for all input types except WHIP. For WHIP, the default is to not transcode.
    */
   enableTranscoding?: boolean | undefined;
+  /**
+   * whether the ingress is enabled. When set to false, new connection attempts are rejected
+   * while the stream key is preserved. The default is true.
+   */
+  enabled?: boolean;
   /**
    * custom audio encoding parameters. optional
    */
@@ -152,6 +162,7 @@ export class IngressClient extends ServiceBase {
 
     const roomName: string | undefined = opts.roomName;
     const enableTranscoding: boolean | undefined = opts.enableTranscoding;
+    const enabled: boolean | undefined = opts.enabled;
     const audio: IngressAudioOptions | undefined = opts.audio;
     const video: IngressVideoOptions | undefined = opts.video;
     const participantMetadata: string | undefined = opts.participantMetadata;
@@ -180,6 +191,7 @@ export class IngressClient extends ServiceBase {
       bypassTranscoding,
       enableTranscoding,
       url,
+      enabled,
       audio,
       video,
     }).toJson();
@@ -203,7 +215,7 @@ export class IngressClient extends ServiceBase {
     const participantName: string = opts.participantName || '';
     const participantIdentity: string = opts.participantIdentity || '';
     const { participantMetadata } = opts;
-    const { audio, video, bypassTranscoding, enableTranscoding } = opts;
+    const { audio, video, bypassTranscoding, enableTranscoding, enabled } = opts;
 
     const req = new UpdateIngressRequest({
       ingressId,
@@ -214,6 +226,7 @@ export class IngressClient extends ServiceBase {
       participantMetadata,
       bypassTranscoding,
       enableTranscoding,
+      enabled,
       audio,
       video,
     }).toJson();


### PR DESCRIPTION
## What

Adds an `enabled?: boolean` option to `CreateIngressOptions` and `UpdateIngressOptions`, and maps it into the underlying `CreateIngressRequest` / `UpdateIngressRequest`.

## Why

The `enabled` field already exists on the protobuf messages (added in livekit/protocol#935) and is enforced by the ingress service (livekit/ingress#319), but the Node server SDK never surfaced it through the typed options. To disable an ingress session without deleting it — so the stream key survives — callers currently have to bypass the SDK and send a raw Twirp `UpdateIngress` (or use the `lk` CLI). This closes that gap so `enabled` is settable through the normal typed API, mirroring how `enableTranscoding` is handled.

Suggested by LiveKit's Developer Solutions Engineer in a support thread about non-destructive ingress disabling.

## Changes

- `CreateIngressOptions.enabled?: boolean` + mapped into `CreateIngressRequest`
- `UpdateIngressOptions.enabled?: boolean` + mapped into `UpdateIngressRequest`
- changeset (patch)

## Testing

- `pnpm --filter livekit-server-sdk build` — clean (declaration emit; `enabled` type-checks against `@livekit/protocol@1.48.0`)
- `pnpm --filter livekit-server-sdk test` — 12/12 passing
- prettier `--check` and eslint clean on the changed file
