### PR TITLE
Port data streams over to rust livekit-ffi version

### DIFF
--- a/.changeset/quiet-ducks-yell.md
+++ b/.changeset/quiet-ducks-yell.md
@@ -1,0 +1,5 @@
+---
+'@livekit/rtc-node': patch
+---
+
+Convert data streams to use livekit-ffi exposed data streams interface

--- a/packages/livekit-rtc/scripts/run-e2e.mjs
+++ b/packages/livekit-rtc/scripts/run-e2e.mjs
@@ -16,6 +16,7 @@ const PORT = 7880;
 const URL = `ws://${HOST}:${PORT}`;
 const API_KEY = 'devkey';
 const API_SECRET = 'secret';
+const TEST_FILES = ['src/tests/e2e.test.ts', 'src/tests/e2e_data_streams.test.ts'];
 
 async function tcpReady(host, port, timeoutMs) {
   const deadline = Date.now() + timeoutMs;
@@ -77,7 +78,7 @@ process.on('SIGTERM', () => onSignal('SIGTERM'));
 try {
   await tcpReady(HOST, PORT, 15_000);
 
-  const args = ['exec', 'vitest', 'run', 'src/tests/e2e.test.ts', ...process.argv.slice(2)];
+  const args = ['exec', 'vitest', 'run', ...TEST_FILES, ...process.argv.slice(2)];
   testProc = spawn('pnpm', args, {
     env: {
       ...process.env,

--- a/packages/livekit-rtc/src/audio_stream_room_lifecycle.test.ts
+++ b/packages/livekit-rtc/src/audio_stream_room_lifecycle.test.ts
@@ -146,12 +146,15 @@ function makeEndTrackingStream(): { stream: AudioStreamSource; endCount: () => n
 
 function makeLocalParticipant(identity: string): LocalParticipant {
   // Bypass the FFI-touching constructor; set only the fields the lifecycle
-  // paths read (identity getter + trackPublications map).
+  // paths read (identity getter, trackPublications map, and the open data
+  // stream writers that disconnect cleanup disposes).
   const p = Object.create(LocalParticipant.prototype) as LocalParticipant;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   (p as any).info = { identity };
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   (p as any).trackPublications = new Map();
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (p as any).openStreamWriters = new Set();
   return p;
 }
 

--- a/packages/livekit-rtc/src/data_streams/stream_reader.ts
+++ b/packages/livekit-rtc/src/data_streams/stream_reader.ts
@@ -66,7 +66,10 @@ export class ByteStreamReader extends BaseStreamReader<ByteStreamInfo> {
           // consumer never calls return() (e.g. breaking out of for-await).
           reader.releaseLock();
           log.error('error processing stream update: %s', error);
-          return { done: true, value: undefined as unknown };
+          // Propagate abnormal termination (e.g. remote abort, payload over
+          // the receiver's size limit) instead of presenting the truncated
+          // payload as a clean EOF.
+          throw error;
         }
       },
 
@@ -153,7 +156,10 @@ export class TextStreamReader extends BaseStreamReader<TextStreamInfo> {
           reader.releaseLock();
           receivedChunks.clear();
           log.error('error processing stream update: %s', error);
-          return { done: true, value: undefined };
+          // Propagate abnormal termination (e.g. remote abort, payload over
+          // the receiver's size limit) instead of presenting the truncated
+          // payload as a clean EOF.
+          throw error;
         }
       },
 

--- a/packages/livekit-rtc/src/data_streams/stream_reader.ts
+++ b/packages/livekit-rtc/src/data_streams/stream_reader.ts
@@ -47,9 +47,13 @@ abstract class BaseStreamReader<T extends BaseStreamInfo> {
     return reader;
   }
 
-  /** Releases the stream lock after an iteration ended on its own — at
-   * end-of-stream or on a stream error. The FFI subscription behind the stream
-   * was already dropped by that terminal event, so there is nothing to cancel. */
+  /** Releases the stream lock after an iteration ended on its own — because a
+   * read reported end-of-stream, or because the stream itself errored. Either
+   * way the stream is in a terminal state and the FFI subscription behind it
+   * was already dropped by that terminal event, so there is nothing to cancel.
+   *
+   * An error raised *around* a read rather than by it — a chunk that failed to
+   * process — leaves the stream live, so it has to go through close() instead. */
   protected finishIteration(reader: ReadableStreamDefaultReader<DataStream_Chunk>) {
     this.closed = true;
     if (this.activeReader === reader) {
@@ -104,25 +108,37 @@ export class ByteStreamReader extends BaseStreamReader<ByteStreamInfo> {
 
     return {
       next: async (): Promise<IteratorResult<Uint8Array>> => {
+        let read: Awaited<ReturnType<typeof reader.read>>;
         try {
-          const { done, value } = await reader.read();
-          if (done) {
-            // Release the lock when the stream is exhausted so the
-            // underlying ReadableStream can be garbage-collected.
-            this.finishIteration(reader);
-            return { done: true, value: undefined as unknown };
-          } else {
-            this.handleChunkReceived(value);
-            return { done: false, value: value.content! };
-          }
+          read = await reader.read();
         } catch (error: unknown) {
-          // Release the lock on error so it doesn't stay held when the
-          // consumer never calls return() (e.g. breaking out of for-await).
+          // The stream errored, which is terminal: release the lock so it
+          // doesn't stay held when the consumer never calls return() (a
+          // rejecting next() doesn't trigger it).
           this.finishIteration(reader);
-          log.error('error processing stream update: %s', error);
+          log.error('error reading stream: %s', error);
           // Propagate abnormal termination (e.g. remote abort, payload over
           // the receiver's size limit) instead of presenting the truncated
           // payload as a clean EOF.
+          throw error;
+        }
+
+        if (read.done) {
+          // Release the lock when the stream is exhausted so the
+          // underlying ReadableStream can be garbage-collected.
+          this.finishIteration(reader);
+          return { done: true, value: undefined as unknown };
+        }
+
+        try {
+          this.handleChunkReceived(read.value);
+          return { done: false, value: read.value.content! };
+        } catch (error: unknown) {
+          // The chunk arrived fine but handling it threw (e.g. a consumer's
+          // onProgress callback). The stream is still live, so it has to be
+          // cancelled to release its FFI subscription.
+          await this.close();
+          log.error('error processing stream update: %s', error);
           throw error;
         }
       },
@@ -158,28 +174,37 @@ export class TextStreamReader extends BaseStreamReader<TextStreamInfo> {
 
     return {
       next: async (): Promise<IteratorResult<string>> => {
+        let read: Awaited<ReturnType<typeof reader.read>>;
         try {
-          const { done, value } = await reader.read();
-          if (done) {
-            // Release the lock when the stream is exhausted so the
-            // underlying ReadableStream can be garbage-collected.
-            this.finishIteration(reader);
-            return { done: true, value: undefined };
-          } else {
-            this.handleChunkReceived(value);
-            return {
-              done: false,
-              value: decoder.decode(value.content!),
-            };
-          }
+          read = await reader.read();
         } catch (error: unknown) {
-          // Release the lock on error so it doesn't stay held when the
-          // consumer never calls return() (e.g. breaking out of for-await).
+          // The stream errored, which is terminal: release the lock so it
+          // doesn't stay held when the consumer never calls return() (a
+          // rejecting next() doesn't trigger it).
           this.finishIteration(reader);
-          log.error('error processing stream update: %s', error);
+          log.error('error reading stream: %s', error);
           // Propagate abnormal termination (e.g. remote abort, payload over
           // the receiver's size limit) instead of presenting the truncated
           // payload as a clean EOF.
+          throw error;
+        }
+
+        if (read.done) {
+          // Release the lock when the stream is exhausted so the
+          // underlying ReadableStream can be garbage-collected.
+          this.finishIteration(reader);
+          return { done: true, value: undefined };
+        }
+
+        try {
+          this.handleChunkReceived(read.value);
+          return { done: false, value: decoder.decode(read.value.content!) };
+        } catch (error: unknown) {
+          // The chunk arrived fine but handling it threw (e.g. a consumer's
+          // onProgress callback). The stream is still live, so it has to be
+          // cancelled to release its FFI subscription.
+          await this.close();
+          log.error('error processing stream update: %s', error);
           throw error;
         }
       },

--- a/packages/livekit-rtc/src/data_streams/stream_reader.ts
+++ b/packages/livekit-rtc/src/data_streams/stream_reader.ts
@@ -3,7 +3,6 @@
 // SPDX-License-Identifier: Apache-2.0
 import type { DataStream_Chunk } from '@livekit/rtc-ffi-bindings';
 import { log } from '../log.js';
-import { bigIntToNumber } from '../utils.js';
 import type { BaseStreamInfo, ByteStreamInfo, TextStreamInfo } from './types.js';
 
 abstract class BaseStreamReader<T extends BaseStreamInfo> {
@@ -14,6 +13,12 @@ abstract class BaseStreamReader<T extends BaseStreamInfo> {
   protected _info: T;
 
   protected bytesReceived: number;
+
+  private closed = false;
+
+  // The reader held by an in-progress iteration. Cancelling has to go through
+  // it, since it holds the stream's lock.
+  private activeReader: ReadableStreamDefaultReader<DataStream_Chunk> | null = null;
 
   get info() {
     return this._info;
@@ -34,6 +39,57 @@ abstract class BaseStreamReader<T extends BaseStreamInfo> {
     this.onProgress?.(currentProgress);
   }
 
+  /** Takes the stream's reader for an iteration, remembering it so that
+   * close() can cancel a read that is still in flight. */
+  protected acquireReader(): ReadableStreamDefaultReader<DataStream_Chunk> {
+    const reader = this.reader.getReader();
+    this.activeReader = reader;
+    return reader;
+  }
+
+  /** Releases the stream lock after an iteration ended on its own — at
+   * end-of-stream or on a stream error. The FFI subscription behind the stream
+   * was already dropped by that terminal event, so there is nothing to cancel. */
+  protected finishIteration(reader: ReadableStreamDefaultReader<DataStream_Chunk>) {
+    this.closed = true;
+    if (this.activeReader === reader) {
+      this.activeReader = null;
+    }
+    reader.releaseLock();
+  }
+
+  /**
+   * Stops receiving this stream and releases the resources behind it.
+   *
+   * A reader is subscribed to FFI events from the moment it is handed to a
+   * stream handler, and only unsubscribes once a read consumes the stream's
+   * end-of-stream event. So a reader that is abandoned part-way through, or
+   * that a handler never reads at all, has to be closed here or its
+   * subscription lives for the rest of the process. Reading to completion — or
+   * breaking out of a `for await` — closes the reader for you, and closing an
+   * already-closed reader is a no-op.
+   */
+  async close(): Promise<void> {
+    if (this.closed) {
+      return;
+    }
+    this.closed = true;
+    const active = this.activeReader;
+    this.activeReader = null;
+    try {
+      if (active) {
+        await active.cancel();
+        active.releaseLock();
+      } else {
+        await this.reader.cancel();
+      }
+    } catch (error: unknown) {
+      // The stream was already closed or errored (e.g. the room disconnected
+      // mid-stream), in which case its subscription is already gone.
+      log.debug('error closing stream reader: %s', error);
+    }
+  }
+
   onProgress?: (progress: number | undefined) => void;
 
   abstract readAll(): Promise<string | Array<Uint8Array>>;
@@ -44,7 +100,7 @@ abstract class BaseStreamReader<T extends BaseStreamInfo> {
  */
 export class ByteStreamReader extends BaseStreamReader<ByteStreamInfo> {
   [Symbol.asyncIterator]() {
-    const reader = this.reader.getReader();
+    const reader = this.acquireReader();
 
     return {
       next: async (): Promise<IteratorResult<Uint8Array>> => {
@@ -53,7 +109,7 @@ export class ByteStreamReader extends BaseStreamReader<ByteStreamInfo> {
           if (done) {
             // Release the lock when the stream is exhausted so the
             // underlying ReadableStream can be garbage-collected.
-            reader.releaseLock();
+            this.finishIteration(reader);
             return { done: true, value: undefined as unknown };
           } else {
             this.handleChunkReceived(value);
@@ -62,7 +118,7 @@ export class ByteStreamReader extends BaseStreamReader<ByteStreamInfo> {
         } catch (error: unknown) {
           // Release the lock on error so it doesn't stay held when the
           // consumer never calls return() (e.g. breaking out of for-await).
-          reader.releaseLock();
+          this.finishIteration(reader);
           log.error('error processing stream update: %s', error);
           // Propagate abnormal termination (e.g. remote abort, payload over
           // the receiver's size limit) instead of presenting the truncated
@@ -71,8 +127,8 @@ export class ByteStreamReader extends BaseStreamReader<ByteStreamInfo> {
         }
       },
 
-      return(): IteratorResult<Uint8Array> {
-        reader.releaseLock();
+      return: async (): Promise<IteratorResult<Uint8Array>> => {
+        await this.close();
         return { done: true, value: undefined };
       },
     };
@@ -91,44 +147,14 @@ export class ByteStreamReader extends BaseStreamReader<ByteStreamInfo> {
  * A class to read chunks from a ReadableStream and provide them in a structured format.
  */
 export class TextStreamReader extends BaseStreamReader<TextStreamInfo> {
-  private receivedChunks: Map<number, DataStream_Chunk>;
-
-  /**
-   * A TextStreamReader instance can be used as an AsyncIterator that returns the entire string
-   * that has been received up to the current point in time.
-   */
-  constructor(
-    info: TextStreamInfo,
-    stream: ReadableStream<DataStream_Chunk>,
-    totalByteSize?: number,
-  ) {
-    super(info, stream, totalByteSize);
-    this.receivedChunks = new Map();
-  }
-
-  protected handleChunkReceived(chunk: DataStream_Chunk) {
-    const index = bigIntToNumber(chunk.chunkIndex!);
-    const previousChunkAtIndex = this.receivedChunks.get(index!);
-    if (previousChunkAtIndex && previousChunkAtIndex.version! > chunk.version!) {
-      // we have a newer version already, dropping the old one
-      return;
-    }
-    this.receivedChunks.set(index, chunk);
-    // Progress is reported against the payload's total byte length, so it has
-    // to be measured in received bytes too — a chunk count would report e.g.
-    // 1/50000 for a payload that arrived as a single chunk.
-    super.handleChunkReceived(chunk);
-  }
-
   /**
    * Async iterator implementation to allow usage of `for await...of` syntax.
    * Yields structured chunks from the stream.
    *
    */
   [Symbol.asyncIterator]() {
-    const reader = this.reader.getReader();
+    const reader = this.acquireReader();
     const decoder = new TextDecoder();
-    const receivedChunks = this.receivedChunks;
 
     return {
       next: async (): Promise<IteratorResult<string>> => {
@@ -137,9 +163,7 @@ export class TextStreamReader extends BaseStreamReader<TextStreamInfo> {
           if (done) {
             // Release the lock when the stream is exhausted so the
             // underlying ReadableStream can be garbage-collected.
-            reader.releaseLock();
-            // Clear received chunks so the buffered data can be GC'd.
-            receivedChunks.clear();
+            this.finishIteration(reader);
             return { done: true, value: undefined };
           } else {
             this.handleChunkReceived(value);
@@ -151,8 +175,7 @@ export class TextStreamReader extends BaseStreamReader<TextStreamInfo> {
         } catch (error: unknown) {
           // Release the lock on error so it doesn't stay held when the
           // consumer never calls return() (e.g. breaking out of for-await).
-          reader.releaseLock();
-          receivedChunks.clear();
+          this.finishIteration(reader);
           log.error('error processing stream update: %s', error);
           // Propagate abnormal termination (e.g. remote abort, payload over
           // the receiver's size limit) instead of presenting the truncated
@@ -161,10 +184,8 @@ export class TextStreamReader extends BaseStreamReader<TextStreamInfo> {
         }
       },
 
-      return(): IteratorResult<string> {
-        reader.releaseLock();
-        // Clear received chunks so the buffered data can be GC'd.
-        receivedChunks.clear();
+      return: async (): Promise<IteratorResult<string>> => {
+        await this.close();
         return { done: true, value: undefined };
       },
     };

--- a/packages/livekit-rtc/src/data_streams/stream_reader.ts
+++ b/packages/livekit-rtc/src/data_streams/stream_reader.ts
@@ -26,7 +26,13 @@ abstract class BaseStreamReader<T extends BaseStreamInfo> {
     this.bytesReceived = 0;
   }
 
-  protected abstract handleChunkReceived(chunk: DataStream_Chunk): void;
+  protected handleChunkReceived(chunk: DataStream_Chunk) {
+    this.bytesReceived += chunk.content!.byteLength;
+    const currentProgress = this.totalByteSize
+      ? this.bytesReceived / this.totalByteSize
+      : undefined;
+    this.onProgress?.(currentProgress);
+  }
 
   onProgress?: (progress: number | undefined) => void;
 
@@ -37,14 +43,6 @@ abstract class BaseStreamReader<T extends BaseStreamInfo> {
  * A class to read chunks from a ReadableStream and provide them in a structured format.
  */
 export class ByteStreamReader extends BaseStreamReader<ByteStreamInfo> {
-  protected handleChunkReceived(chunk: DataStream_Chunk) {
-    this.bytesReceived += chunk.content!.byteLength;
-    const currentProgress = this.totalByteSize
-      ? this.bytesReceived / this.totalByteSize
-      : undefined;
-    this.onProgress?.(currentProgress);
-  }
-
   [Symbol.asyncIterator]() {
     const reader = this.reader.getReader();
 
@@ -102,9 +100,9 @@ export class TextStreamReader extends BaseStreamReader<TextStreamInfo> {
   constructor(
     info: TextStreamInfo,
     stream: ReadableStream<DataStream_Chunk>,
-    totalChunkCount?: number,
+    totalByteSize?: number,
   ) {
-    super(info, stream, totalChunkCount);
+    super(info, stream, totalByteSize);
     this.receivedChunks = new Map();
   }
 
@@ -116,10 +114,10 @@ export class TextStreamReader extends BaseStreamReader<TextStreamInfo> {
       return;
     }
     this.receivedChunks.set(index, chunk);
-    const currentProgress = this.totalByteSize
-      ? this.receivedChunks.size / this.totalByteSize
-      : undefined;
-    this.onProgress?.(currentProgress);
+    // Progress is reported against the payload's total byte length, so it has
+    // to be measured in received bytes too — a chunk count would report e.g.
+    // 1/50000 for a payload that arrived as a single chunk.
+    super.handleChunkReceived(chunk);
   }
 
   /**

--- a/packages/livekit-rtc/src/data_streams/types.ts
+++ b/packages/livekit-rtc/src/data_streams/types.ts
@@ -42,6 +42,12 @@ export interface TextStreamOptions extends DataStreamOptions {
 export interface ByteStreamOptions extends DataStreamOptions {
   name?: string;
   onProgress?: (progress: number) => void;
+  /**
+   * Whether the payload may be compressed on the wire. Defaults to true;
+   * compression is only applied when it actually reduces the payload size
+   * and every recipient supports it.
+   */
+  compress?: boolean;
 }
 
 export type ByteStreamHandler = (

--- a/packages/livekit-rtc/src/participant.ts
+++ b/packages/livekit-rtc/src/participant.ts
@@ -285,7 +285,6 @@ export class LocalParticipant extends Participant {
     destinationIdentities?: Array<string>;
     streamId?: string;
     senderIdentity?: string;
-    totalSize?: number;
   }): Promise<TextStreamWriter> {
     const req = new TextStreamOpenRequest({
       localParticipantHandle: this.ffi_handle.handle,
@@ -295,7 +294,6 @@ export class LocalParticipant extends Participant {
         destinationIdentities: options?.destinationIdentities,
         id: options?.streamId,
         senderIdentity: options?.senderIdentity ?? this.identity,
-        totalSize: options?.totalSize,
       }),
     });
 
@@ -354,6 +352,12 @@ export class LocalParticipant extends Participant {
       attributes?: Record<string, string>;
       destinationIdentities?: Array<string>;
       streamId?: string;
+      /**
+       * Whether the payload may be compressed on the wire. Defaults to true;
+       * compression is only applied when it actually reduces the payload size
+       * and every recipient supports it.
+       */
+      compress?: boolean;
     },
   ) {
     const req = new StreamSendTextRequest({
@@ -364,6 +368,7 @@ export class LocalParticipant extends Participant {
         destinationIdentities: options?.destinationIdentities,
         id: options?.streamId,
         senderIdentity: this.identity,
+        compress: options?.compress,
       }),
       text,
     });
@@ -467,6 +472,7 @@ export class LocalParticipant extends Participant {
         name: options?.name ?? 'unknown',
         mimeType: options?.mimeType ?? 'application/octet-stream',
         senderIdentity: this.identity,
+        compress: options?.compress,
       }),
       filePath,
     });

--- a/packages/livekit-rtc/src/participant.ts
+++ b/packages/livekit-rtc/src/participant.ts
@@ -497,8 +497,7 @@ export class LocalParticipant extends Participant {
     });
 
     const cb = await FfiClient.instance.waitFor<TextStreamWriterWriteCallback>(
-      (ev) =>
-        ev.message.case == 'textStreamWriterWrite' && ev.message.value.asyncId == res.asyncId,
+      (ev) => ev.message.case == 'textStreamWriterWrite' && ev.message.value.asyncId == res.asyncId,
       { signal: this.disconnectSignal },
     );
 
@@ -513,8 +512,7 @@ export class LocalParticipant extends Participant {
     });
 
     const cb = await FfiClient.instance.waitFor<TextStreamWriterCloseCallback>(
-      (ev) =>
-        ev.message.case == 'textStreamWriterClose' && ev.message.value.asyncId == res.asyncId,
+      (ev) => ev.message.case == 'textStreamWriterClose' && ev.message.value.asyncId == res.asyncId,
       { signal: this.disconnectSignal },
     );
 
@@ -529,8 +527,7 @@ export class LocalParticipant extends Participant {
     });
 
     const cb = await FfiClient.instance.waitFor<ByteStreamWriterWriteCallback>(
-      (ev) =>
-        ev.message.case == 'byteStreamWriterWrite' && ev.message.value.asyncId == res.asyncId,
+      (ev) => ev.message.case == 'byteStreamWriterWrite' && ev.message.value.asyncId == res.asyncId,
       { signal: this.disconnectSignal },
     );
 
@@ -545,8 +542,7 @@ export class LocalParticipant extends Participant {
     });
 
     const cb = await FfiClient.instance.waitFor<ByteStreamWriterCloseCallback>(
-      (ev) =>
-        ev.message.case == 'byteStreamWriterClose' && ev.message.value.asyncId == res.asyncId,
+      (ev) => ev.message.case == 'byteStreamWriterClose' && ev.message.value.asyncId == res.asyncId,
       { signal: this.disconnectSignal },
     );
 

--- a/packages/livekit-rtc/src/participant.ts
+++ b/packages/livekit-rtc/src/participant.ts
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2024 LiveKit, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
-import { Mutex } from '@livekit/mutex';
+import { type Mutex } from '@livekit/mutex';
 import {
   DisconnectReason,
   type OwnedParticipant,
@@ -10,13 +10,16 @@ import {
   type ParticipantKindDetail,
 } from '@livekit/rtc-ffi-bindings';
 import {
+  type ByteStreamOpenCallback,
+  ByteStreamOpenRequest,
+  type ByteStreamOpenResponse,
+  type ByteStreamWriterCloseCallback,
+  ByteStreamWriterCloseRequest,
+  type ByteStreamWriterCloseResponse,
+  type ByteStreamWriterWriteCallback,
+  ByteStreamWriterWriteRequest,
+  type ByteStreamWriterWriteResponse,
   ChatMessage as ChatMessageModel,
-  DataStream_ByteHeader,
-  DataStream_Chunk,
-  DataStream_Header,
-  DataStream_OperationType,
-  DataStream_TextHeader,
-  DataStream_Trailer,
   EditChatMessageRequest,
   TranscriptionSegment as ProtoTranscriptionSegment,
   type PublishDataCallback,
@@ -34,15 +37,6 @@ import {
   type SendChatMessageCallback,
   SendChatMessageRequest,
   type SendChatMessageResponse,
-  type SendStreamChunkCallback,
-  SendStreamChunkRequest,
-  type SendStreamChunkResponse,
-  type SendStreamHeaderCallback,
-  SendStreamHeaderRequest,
-  type SendStreamHeaderResponse,
-  type SendStreamTrailerCallback,
-  SendStreamTrailerRequest,
-  type SendStreamTrailerResponse,
   type SetLocalAttributesCallback,
   SetLocalAttributesRequest,
   type SetLocalAttributesResponse,
@@ -52,6 +46,23 @@ import {
   type SetLocalNameCallback,
   SetLocalNameRequest,
   type SetLocalNameResponse,
+  StreamByteOptions,
+  type StreamSendFileCallback,
+  StreamSendFileRequest,
+  type StreamSendFileResponse,
+  type StreamSendTextCallback,
+  StreamSendTextRequest,
+  type StreamSendTextResponse,
+  StreamTextOptions,
+  type TextStreamOpenCallback,
+  TextStreamOpenRequest,
+  type TextStreamOpenResponse,
+  type TextStreamWriterCloseCallback,
+  TextStreamWriterCloseRequest,
+  type TextStreamWriterCloseResponse,
+  type TextStreamWriterWriteCallback,
+  TextStreamWriterWriteRequest,
+  type TextStreamWriterWriteResponse,
   type TrackPublishOptions,
   type UnpublishTrackCallback,
   UnpublishTrackRequest,
@@ -71,12 +82,10 @@ import {
   UnregisterRpcMethodRequest,
 } from '@livekit/rtc-ffi-bindings';
 import type { PathLike } from 'node:fs';
-import { open, stat } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
 import {
-  type ByteStreamInfo,
   type ByteStreamOptions,
   ByteStreamWriter,
-  type TextStreamInfo,
   TextStreamWriter,
 } from './data_streams/index.js';
 import { FfiClient, FfiHandle } from './ffi_client.js';
@@ -87,9 +96,8 @@ import type { RemoteTrackPublication, TrackPublication } from './track_publicati
 import { LocalTrackPublication } from './track_publication.js';
 import type { Transcription } from './transcription.js';
 import type { ChatMessage } from './types.js';
-import { numberToBigInt, splitUtf8 } from './utils.js';
-
-const STREAM_CHUNK_SIZE = 15_000;
+import { byteStreamInfoFromProto, textStreamInfoFromProto } from './utils.js';
+import { numberToBigInt } from './utils.js';
 
 export abstract class Participant {
   /** @internal */
@@ -279,94 +287,55 @@ export class LocalParticipant extends Participant {
     senderIdentity?: string;
     totalSize?: number;
   }): Promise<TextStreamWriter> {
-    const senderIdentity = options?.senderIdentity ?? this.identity;
-    const streamId = options?.streamId ?? crypto.randomUUID();
-    const destinationIdentities = options?.destinationIdentities;
-
-    const info: TextStreamInfo = {
-      streamId: streamId,
-      mimeType: 'text/plain',
-      topic: options?.topic ?? '',
-      timestamp: Date.now(),
-      totalSize: options?.totalSize,
-    };
-
-    const headerReq = new SendStreamHeaderRequest({
-      senderIdentity,
-      destinationIdentities,
+    const req = new TextStreamOpenRequest({
       localParticipantHandle: this.ffi_handle.handle,
-      header: new DataStream_Header({
-        streamId,
-        mimeType: info.mimeType,
-        topic: info.topic,
-        timestamp: numberToBigInt(info.timestamp),
-        totalLength: numberToBigInt(info.totalSize),
+      options: new StreamTextOptions({
+        topic: options?.topic ?? '',
         attributes: options?.attributes,
-        contentHeader: {
-          case: 'textHeader',
-          value: new DataStream_TextHeader({
-            operationType: DataStream_OperationType.CREATE,
-            version: 0,
-            replyToStreamId: '',
-            generated: false,
-          }),
-        },
+        destinationIdentities: options?.destinationIdentities,
+        id: options?.streamId,
+        senderIdentity: options?.senderIdentity ?? this.identity,
+        totalSize: options?.totalSize,
       }),
     });
 
-    await this.sendStreamHeader(headerReq);
+    const res = FfiClient.instance.request<TextStreamOpenResponse>({
+      message: { case: 'textStreamOpen', value: req },
+    });
 
-    let nextChunkId = 0;
-    const localHandle = this.ffi_handle.handle;
-    const sendTrailer = this.sendStreamTrailer;
-    const sendChunk = this.sendStreamChunk;
+    const cb = await FfiClient.instance.waitFor<TextStreamOpenCallback>(
+      (ev) => ev.message.case == 'textStreamOpen' && ev.message.value.asyncId == res.asyncId,
+      { signal: this.disconnectSignal },
+    );
+
+    if (cb.result.case !== 'writer') {
+      throw new Error(cb.result.case === 'error' ? cb.result.value.description : 'unknown error');
+    }
+
+    const writerHandle = cb.result.value.handle!.id!;
+    const info = textStreamInfoFromProto(cb.result.value.info!);
+    const writeText = this.textStreamWriterWrite;
+    const closeWriter = this.textStreamWriterClose;
 
     const writableStream = new WritableStream<string>({
       // Implement the sink
       async write(text) {
-        for (const textByteChunk of splitUtf8(text, STREAM_CHUNK_SIZE)) {
-          const chunkRequest = new SendStreamChunkRequest({
-            senderIdentity,
-            localParticipantHandle: localHandle,
-            destinationIdentities,
-            chunk: new DataStream_Chunk({
-              content: textByteChunk,
-              streamId,
-              chunkIndex: numberToBigInt(nextChunkId),
-            }),
-          });
-
-          await sendChunk(chunkRequest);
-          nextChunkId += 1;
-        }
+        await writeText(new TextStreamWriterWriteRequest({ writerHandle, text }));
       },
       async close() {
-        const trailerReq = new SendStreamTrailerRequest({
-          senderIdentity,
-          localParticipantHandle: localHandle,
-          destinationIdentities,
-          trailer: new DataStream_Trailer({
-            streamId,
-            reason: '',
-          }),
-        });
-        await sendTrailer(trailerReq);
+        await closeWriter(new TextStreamWriterCloseRequest({ writerHandle }));
       },
-      // Send a trailer with the error reason so the remote side's stream
+      // Close the stream with the error reason so the remote side's stream
       // controller is closed instead of waiting for data that won't arrive.
       async abort(err) {
         log.error(err, 'Sink Error');
         try {
-          const trailerReq = new SendStreamTrailerRequest({
-            senderIdentity,
-            localParticipantHandle: localHandle,
-            destinationIdentities,
-            trailer: new DataStream_Trailer({
-              streamId,
+          await closeWriter(
+            new TextStreamWriterCloseRequest({
+              writerHandle,
               reason: err instanceof Error ? err.message : String(err ?? ''),
             }),
-          });
-          await sendTrailer(trailerReq);
+          );
         } catch {
           // Best-effort: the connection may already be gone.
         }
@@ -387,13 +356,32 @@ export class LocalParticipant extends Participant {
       streamId?: string;
     },
   ) {
-    const writer = await this.streamText({
-      ...options,
-      totalSize: new TextEncoder().encode(text).byteLength,
+    const req = new StreamSendTextRequest({
+      localParticipantHandle: this.ffi_handle.handle,
+      options: new StreamTextOptions({
+        topic: options?.topic ?? '',
+        attributes: options?.attributes,
+        destinationIdentities: options?.destinationIdentities,
+        id: options?.streamId,
+        senderIdentity: this.identity,
+      }),
+      text,
     });
-    await writer.write(text);
-    await writer.close();
-    return writer.info;
+
+    const res = FfiClient.instance.request<StreamSendTextResponse>({
+      message: { case: 'sendText', value: req },
+    });
+
+    const cb = await FfiClient.instance.waitFor<StreamSendTextCallback>(
+      (ev) => ev.message.case == 'sendText' && ev.message.value.asyncId == res.asyncId,
+      { signal: this.disconnectSignal },
+    );
+
+    if (cb.result.case !== 'info') {
+      throw new Error(cb.result.case === 'error' ? cb.result.value.description : 'unknown error');
+    }
+
+    return textStreamInfoFromProto(cb.result.value);
   }
 
   async streamBytes(options?: {
@@ -405,102 +393,56 @@ export class LocalParticipant extends Participant {
     mimeType?: string;
     totalSize?: number;
   }) {
-    const senderIdentity = this.identity;
-    const streamId = options?.streamId ?? crypto.randomUUID();
-    const destinationIdentities = options?.destinationIdentities;
-
-    const info: ByteStreamInfo = {
-      streamId: streamId,
-      mimeType: options?.mimeType ?? 'application/octet-stream',
-      topic: options?.topic ?? '',
-      timestamp: Date.now(),
-      attributes: options?.attributes,
-      totalSize: options?.totalSize,
-      name: options?.name ?? 'unknown',
-    };
-
-    const headerReq = new SendStreamHeaderRequest({
-      senderIdentity,
-      destinationIdentities,
+    const req = new ByteStreamOpenRequest({
       localParticipantHandle: this.ffi_handle.handle,
-      header: new DataStream_Header({
-        streamId,
-        mimeType: info.mimeType,
-        topic: info.topic,
-        timestamp: numberToBigInt(info.timestamp),
-        attributes: info.attributes,
-        totalLength: numberToBigInt(info.totalSize),
-        contentHeader: {
-          case: 'byteHeader',
-          value: new DataStream_ByteHeader({
-            name: info.name,
-          }),
-        },
+      options: new StreamByteOptions({
+        topic: options?.topic ?? '',
+        attributes: options?.attributes,
+        destinationIdentities: options?.destinationIdentities,
+        id: options?.streamId,
+        name: options?.name ?? 'unknown',
+        mimeType: options?.mimeType ?? 'application/octet-stream',
+        totalLength: numberToBigInt(options?.totalSize),
+        senderIdentity: this.identity,
       }),
     });
 
-    await this.sendStreamHeader(headerReq);
+    const res = FfiClient.instance.request<ByteStreamOpenResponse>({
+      message: { case: 'byteStreamOpen', value: req },
+    });
 
-    let chunkId = 0;
-    const localHandle = this.ffi_handle.handle;
-    const sendTrailer = this.sendStreamTrailer;
-    const sendChunk = this.sendStreamChunk;
-    const writeMutex = new Mutex();
+    const cb = await FfiClient.instance.waitFor<ByteStreamOpenCallback>(
+      (ev) => ev.message.case == 'byteStreamOpen' && ev.message.value.asyncId == res.asyncId,
+      { signal: this.disconnectSignal },
+    );
+
+    if (cb.result.case !== 'writer') {
+      throw new Error(cb.result.case === 'error' ? cb.result.value.description : 'unknown error');
+    }
+
+    const writerHandle = cb.result.value.handle!.id!;
+    const info = byteStreamInfoFromProto(cb.result.value.info!);
+    const writeBytes = this.byteStreamWriterWrite;
+    const closeWriter = this.byteStreamWriterClose;
 
     const writableStream = new WritableStream<Uint8Array>({
       async write(chunk) {
-        const unlock = await writeMutex.lock();
-
-        let byteOffset = 0;
-        try {
-          while (byteOffset < chunk.byteLength) {
-            const subChunk = chunk.slice(byteOffset, byteOffset + STREAM_CHUNK_SIZE);
-            const chunkRequest = new SendStreamChunkRequest({
-              senderIdentity,
-              localParticipantHandle: localHandle,
-              destinationIdentities,
-              chunk: new DataStream_Chunk({
-                content: subChunk,
-                streamId,
-                chunkIndex: numberToBigInt(chunkId),
-              }),
-            });
-
-            await sendChunk(chunkRequest);
-            chunkId += 1;
-            byteOffset += subChunk.byteLength;
-          }
-        } finally {
-          unlock();
-        }
+        await writeBytes(new ByteStreamWriterWriteRequest({ writerHandle, bytes: chunk }));
       },
       async close() {
-        const trailerReq = new SendStreamTrailerRequest({
-          senderIdentity,
-          localParticipantHandle: localHandle,
-          destinationIdentities,
-          trailer: new DataStream_Trailer({
-            streamId,
-            reason: '',
-          }),
-        });
-        await sendTrailer(trailerReq);
+        await closeWriter(new ByteStreamWriterCloseRequest({ writerHandle }));
       },
-      // Send a trailer with the error reason so the remote side's stream
+      // Close the stream with the error reason so the remote side's stream
       // controller is closed instead of waiting for data that won't arrive.
       async abort(err) {
         log.error(err, 'Sink error');
         try {
-          const trailerReq = new SendStreamTrailerRequest({
-            senderIdentity,
-            localParticipantHandle: localHandle,
-            destinationIdentities,
-            trailer: new DataStream_Trailer({
-              streamId,
+          await closeWriter(
+            new ByteStreamWriterCloseRequest({
+              writerHandle,
               reason: err instanceof Error ? err.message : String(err ?? ''),
             }),
-          });
-          await sendTrailer(trailerReq);
+          );
         } catch {
           // Best-effort: the connection may already be gone.
         }
@@ -514,77 +456,96 @@ export class LocalParticipant extends Participant {
 
   /** Sends a file provided as PathLike to specified recipients */
   async sendFile(path: PathLike, options?: ByteStreamOptions) {
-    const fileStats = await stat(path);
-    const file = await open(path);
-    try {
-      const stream: ReadableStream<Uint8Array> = file.readableWebStream();
-      const streamId = crypto.randomUUID();
-      const destinationIdentities = options?.destinationIdentities;
+    const filePath = path instanceof URL ? fileURLToPath(path) : path.toString();
 
-      const writer = await this.streamBytes({
-        streamId: streamId,
-        name: options?.name,
-        totalSize: fileStats.size,
-        destinationIdentities,
-        topic: options?.topic,
-        mimeType: options?.mimeType,
+    const req = new StreamSendFileRequest({
+      localParticipantHandle: this.ffi_handle.handle,
+      options: new StreamByteOptions({
+        topic: options?.topic ?? '',
         attributes: options?.attributes,
-      });
+        destinationIdentities: options?.destinationIdentities,
+        name: options?.name ?? 'unknown',
+        mimeType: options?.mimeType ?? 'application/octet-stream',
+        senderIdentity: this.identity,
+      }),
+      filePath,
+    });
 
-      for await (const chunk of stream) {
-        await writer.write(chunk);
-      }
-      await writer.close();
-    } finally {
-      await file.close();
+    const res = FfiClient.instance.request<StreamSendFileResponse>({
+      message: { case: 'sendFile', value: req },
+    });
+
+    const cb = await FfiClient.instance.waitFor<StreamSendFileCallback>(
+      (ev) => ev.message.case == 'sendFile' && ev.message.value.asyncId == res.asyncId,
+      { signal: this.disconnectSignal },
+    );
+
+    if (cb.result.case === 'error') {
+      throw new Error(cb.result.value.description);
     }
   }
 
-  private async sendStreamHeader(req: SendStreamHeaderRequest) {
-    const type = 'sendStreamHeader';
-    const res = FfiClient.instance.request<SendStreamHeaderResponse>({
-      message: { case: type, value: req },
+  private textStreamWriterWrite = async (req: TextStreamWriterWriteRequest) => {
+    const res = FfiClient.instance.request<TextStreamWriterWriteResponse>({
+      message: { case: 'textStreamWrite', value: req },
     });
 
-    const cb = await FfiClient.instance.waitFor<SendStreamHeaderCallback>(
-      (ev) => ev.message.case == type && ev.message.value.asyncId == res.asyncId,
+    const cb = await FfiClient.instance.waitFor<TextStreamWriterWriteCallback>(
+      (ev) =>
+        ev.message.case == 'textStreamWriterWrite' && ev.message.value.asyncId == res.asyncId,
       { signal: this.disconnectSignal },
     );
 
     if (cb.error) {
-      throw new Error(cb.error);
-    }
-  }
-
-  private sendStreamChunk = async (req: SendStreamChunkRequest) => {
-    const type = 'sendStreamChunk';
-    const res = FfiClient.instance.request<SendStreamChunkResponse>({
-      message: { case: type, value: req },
-    });
-
-    const cb = await FfiClient.instance.waitFor<SendStreamChunkCallback>(
-      (ev) => ev.message.case == type && ev.message.value.asyncId == res.asyncId,
-      { signal: this.disconnectSignal },
-    );
-
-    if (cb.error) {
-      throw new Error(cb.error);
+      throw new Error(cb.error.description);
     }
   };
 
-  private sendStreamTrailer = async (req: SendStreamTrailerRequest) => {
-    const type = 'sendStreamTrailer';
-    const res = FfiClient.instance.request<SendStreamTrailerResponse>({
-      message: { case: type, value: req },
+  private textStreamWriterClose = async (req: TextStreamWriterCloseRequest) => {
+    const res = FfiClient.instance.request<TextStreamWriterCloseResponse>({
+      message: { case: 'textStreamClose', value: req },
     });
 
-    const cb = await FfiClient.instance.waitFor<SendStreamTrailerCallback>(
-      (ev) => ev.message.case == type && ev.message.value.asyncId == res.asyncId,
+    const cb = await FfiClient.instance.waitFor<TextStreamWriterCloseCallback>(
+      (ev) =>
+        ev.message.case == 'textStreamWriterClose' && ev.message.value.asyncId == res.asyncId,
       { signal: this.disconnectSignal },
     );
 
     if (cb.error) {
-      throw new Error(cb.error);
+      throw new Error(cb.error.description);
+    }
+  };
+
+  private byteStreamWriterWrite = async (req: ByteStreamWriterWriteRequest) => {
+    const res = FfiClient.instance.request<ByteStreamWriterWriteResponse>({
+      message: { case: 'byteStreamWrite', value: req },
+    });
+
+    const cb = await FfiClient.instance.waitFor<ByteStreamWriterWriteCallback>(
+      (ev) =>
+        ev.message.case == 'byteStreamWriterWrite' && ev.message.value.asyncId == res.asyncId,
+      { signal: this.disconnectSignal },
+    );
+
+    if (cb.error) {
+      throw new Error(cb.error.description);
+    }
+  };
+
+  private byteStreamWriterClose = async (req: ByteStreamWriterCloseRequest) => {
+    const res = FfiClient.instance.request<ByteStreamWriterCloseResponse>({
+      message: { case: 'byteStreamClose', value: req },
+    });
+
+    const cb = await FfiClient.instance.waitFor<ByteStreamWriterCloseCallback>(
+      (ev) =>
+        ev.message.case == 'byteStreamWriterClose' && ev.message.value.asyncId == res.asyncId,
+      { signal: this.disconnectSignal },
+    );
+
+    if (cb.error) {
+      throw new Error(cb.error.description);
     }
   };
 

--- a/packages/livekit-rtc/src/participant.ts
+++ b/packages/livekit-rtc/src/participant.ts
@@ -174,6 +174,14 @@ export class LocalParticipant extends Participant {
   // pending FfiClient.waitFor() listeners so they don't leak.
   private disconnectSignal: AbortSignal;
 
+  // Handle ids of data stream writers that have been opened but not yet
+  // closed. The FFI close request consumes the handle (take_handle), so an
+  // entry is removed as soon as a close is sent for it; whatever is left when
+  // the room disconnects is dropped by disposeOpenStreamWriters(). Only the
+  // ids are kept — wrapping them in FfiHandle would make GC drop a handle the
+  // close request already consumed.
+  private openStreamWriters = new Set<bigint>();
+
   trackPublications: Map<string, LocalTrackPublication> = new Map();
 
   constructor(info: OwnedParticipant, ffiEventLock: Mutex, disconnectSignal: AbortSignal) {
@@ -312,28 +320,44 @@ export class LocalParticipant extends Participant {
 
     const writerHandle = cb.result.value.handle!.id!;
     const info = textStreamInfoFromProto(cb.result.value.info!);
-    const writeText = this.textStreamWriterWrite;
-    const closeWriter = this.textStreamWriterClose;
+    this.openStreamWriters.add(writerHandle);
+
+    // Sends the close request at most once: it consumes the writer handle on
+    // the native side, so a second one would fail and, worse, the handle must
+    // no longer be dropped by disconnect cleanup.
+    const closeWriter = async (reason?: string) => {
+      if (!this.openStreamWriters.delete(writerHandle)) {
+        return;
+      }
+      await this.textStreamWriterClose(new TextStreamWriterCloseRequest({ writerHandle, reason }));
+    };
 
     const writableStream = new WritableStream<string>({
       // Implement the sink
-      async write(text) {
-        await writeText(new TextStreamWriterWriteRequest({ writerHandle, text }));
+      write: async (text) => {
+        try {
+          await this.textStreamWriterWrite(
+            new TextStreamWriterWriteRequest({ writerHandle, text }),
+          );
+        } catch (err) {
+          // A rejected write leaves the writable stream errored, and an errored
+          // stream never runs the sink's close()/abort() — a later close() just
+          // rejects with this error. Close the native writer here so its handle
+          // isn't held for the lifetime of the process and peers get an
+          // end-of-stream instead of a stream that never terminates.
+          await closeWriter(err instanceof Error ? err.message : String(err ?? '')).catch(() => {
+            // Best-effort: the connection may already be gone.
+          });
+          throw err;
+        }
       },
-      async close() {
-        await closeWriter(new TextStreamWriterCloseRequest({ writerHandle }));
-      },
+      close: () => closeWriter(),
       // Close the stream with the error reason so the remote side's stream
       // controller is closed instead of waiting for data that won't arrive.
-      async abort(err) {
+      abort: async (err) => {
         log.error(err, 'Sink Error');
         try {
-          await closeWriter(
-            new TextStreamWriterCloseRequest({
-              writerHandle,
-              reason: err instanceof Error ? err.message : String(err ?? ''),
-            }),
-          );
+          await closeWriter(err instanceof Error ? err.message : String(err ?? ''));
         } catch {
           // Best-effort: the connection may already be gone.
         }
@@ -427,27 +451,43 @@ export class LocalParticipant extends Participant {
 
     const writerHandle = cb.result.value.handle!.id!;
     const info = byteStreamInfoFromProto(cb.result.value.info!);
-    const writeBytes = this.byteStreamWriterWrite;
-    const closeWriter = this.byteStreamWriterClose;
+    this.openStreamWriters.add(writerHandle);
+
+    // Sends the close request at most once: it consumes the writer handle on
+    // the native side, so a second one would fail and, worse, the handle must
+    // no longer be dropped by disconnect cleanup.
+    const closeWriter = async (reason?: string) => {
+      if (!this.openStreamWriters.delete(writerHandle)) {
+        return;
+      }
+      await this.byteStreamWriterClose(new ByteStreamWriterCloseRequest({ writerHandle, reason }));
+    };
 
     const writableStream = new WritableStream<Uint8Array>({
-      async write(chunk) {
-        await writeBytes(new ByteStreamWriterWriteRequest({ writerHandle, bytes: chunk }));
+      write: async (chunk) => {
+        try {
+          await this.byteStreamWriterWrite(
+            new ByteStreamWriterWriteRequest({ writerHandle, bytes: chunk }),
+          );
+        } catch (err) {
+          // A rejected write leaves the writable stream errored, and an errored
+          // stream never runs the sink's close()/abort() — a later close() just
+          // rejects with this error. Close the native writer here so its handle
+          // isn't held for the lifetime of the process and peers get an
+          // end-of-stream instead of a stream that never terminates.
+          await closeWriter(err instanceof Error ? err.message : String(err ?? '')).catch(() => {
+            // Best-effort: the connection may already be gone.
+          });
+          throw err;
+        }
       },
-      async close() {
-        await closeWriter(new ByteStreamWriterCloseRequest({ writerHandle }));
-      },
+      close: () => closeWriter(),
       // Close the stream with the error reason so the remote side's stream
       // controller is closed instead of waiting for data that won't arrive.
-      async abort(err) {
+      abort: async (err) => {
         log.error(err, 'Sink error');
         try {
-          await closeWriter(
-            new ByteStreamWriterCloseRequest({
-              writerHandle,
-              reason: err instanceof Error ? err.message : String(err ?? ''),
-            }),
-          );
+          await closeWriter(err instanceof Error ? err.message : String(err ?? ''));
         } catch {
           // Best-effort: the connection may already be gone.
         }
@@ -550,6 +590,26 @@ export class LocalParticipant extends Participant {
       throw new Error(cb.error.description);
     }
   };
+
+  /**
+   * Drops the native writers of any data streams that were opened but never
+   * closed — a writer the caller abandoned, or one whose write failed. Their
+   * handles would otherwise be held by the FFI server for the lifetime of the
+   * process. The room is already gone at this point, so the handles are dropped
+   * directly rather than closed: there is no end-of-stream left to deliver.
+   *
+   * @internal
+   */
+  disposeOpenStreamWriters() {
+    for (const writerHandle of this.openStreamWriters) {
+      try {
+        new FfiHandle(writerHandle).dispose();
+      } catch (err) {
+        log.warn('failed to dispose data stream writer handle: %s', err);
+      }
+    }
+    this.openStreamWriters.clear();
+  }
 
   /**
    * Sends a chat message to participants in the room

--- a/packages/livekit-rtc/src/room.ts
+++ b/packages/livekit-rtc/src/room.ts
@@ -981,12 +981,17 @@ export class Room extends (EventEmitter as new () => TypedEmitter<RoomCallbacks>
               );
             }
           } else if (detail.case === 'eos') {
-            // End-of-stream (including a remote abort carrying an error) closes the
-            // stream normally so consumers see EOF, matching the trailer behavior of
-            // the previous implementation.
             FfiClient.instance.off(FfiClientEvent.FfiEvent, listener);
             this.streamReaders.delete(readerHandle);
-            controller.close();
+            const error = detail.value.error;
+            if (error) {
+              // Abnormal termination (e.g. remote abort, payload over the
+              // receiver's size limit): surface the error to the consumer
+              // instead of presenting a truncated payload as a clean EOF.
+              controller.error(new Error(error.description ?? 'stream terminated'));
+            } else {
+              controller.close();
+            }
           }
         };
         FfiClient.instance.on(FfiClientEvent.FfiEvent, listener);
@@ -1042,12 +1047,17 @@ export class Room extends (EventEmitter as new () => TypedEmitter<RoomCallbacks>
               );
             }
           } else if (detail.case === 'eos') {
-            // End-of-stream (including a remote abort carrying an error) closes the
-            // stream normally so consumers see EOF, matching the trailer behavior of
-            // the previous implementation.
             FfiClient.instance.off(FfiClientEvent.FfiEvent, listener);
             this.streamReaders.delete(readerHandle);
-            controller.close();
+            const error = detail.value.error;
+            if (error) {
+              // Abnormal termination (e.g. remote abort, payload over the
+              // receiver's size limit): surface the error to the consumer
+              // instead of presenting a truncated payload as a clean EOF.
+              controller.error(new Error(error.description ?? 'stream terminated'));
+            } else {
+              controller.close();
+            }
           }
         };
         FfiClient.instance.on(FfiClientEvent.FfiEvent, listener);

--- a/packages/livekit-rtc/src/room.ts
+++ b/packages/livekit-rtc/src/room.ts
@@ -9,12 +9,10 @@ import type {
   GetSessionStatsResponse,
 } from '@livekit/rtc-ffi-bindings';
 import { DisconnectReason, type OwnedParticipant } from '@livekit/rtc-ffi-bindings';
-import type {
-  DataStream_Trailer,
-  DisconnectCallback,
-  TrackPublicationInfo,
-} from '@livekit/rtc-ffi-bindings';
+import { type DisconnectCallback, type TrackPublicationInfo } from '@livekit/rtc-ffi-bindings';
 import {
+  ByteStreamReaderReadIncrementalRequest,
+  type ByteStreamReaderReadIncrementalResponse,
   type ConnectCallback,
   ConnectRequest,
   type ConnectResponse,
@@ -22,30 +20,27 @@ import {
   ConnectionState,
   ContinualGatheringPolicy,
   type DataPacketKind,
-  type DataStream_Chunk,
-  type DataStream_Header,
+  DataStream_Chunk,
   type DisconnectResponse,
   RoomOptions as FfiRoomOptions,
   type IceServer,
   IceTransportType,
+  type OwnedByteStreamReader,
+  type OwnedTextStreamReader,
   type ReadyForRoomEventResponse,
   RoomDataStreamOptions,
   type RoomInfo,
   type SimulateScenarioCallback,
   type SimulateScenarioKind,
   type SimulateScenarioResponse,
+  TextStreamReaderReadIncrementalRequest,
+  type TextStreamReaderReadIncrementalResponse,
 } from '@livekit/rtc-ffi-bindings';
 import { TrackKind } from '@livekit/rtc-ffi-bindings';
 import type { TypedEventEmitter as TypedEmitter } from '@livekit/typed-emitter';
 import EventEmitter from 'events';
 import { ByteStreamReader, TextStreamReader } from './data_streams/stream_reader.js';
-import type {
-  ByteStreamHandler,
-  ByteStreamInfo,
-  StreamController,
-  TextStreamHandler,
-  TextStreamInfo,
-} from './data_streams/types.js';
+import { type ByteStreamHandler, type TextStreamHandler } from './data_streams/types.js';
 import type { E2EEOptions } from './e2ee.js';
 import { E2EEManager, defaultE2EEOptions } from './e2ee.js';
 import { FfiClient, FfiClientEvent, FfiHandle } from './ffi_client.js';
@@ -57,7 +52,12 @@ import { RemoteAudioTrack, RemoteVideoTrack } from './track.js';
 import type { LocalTrackPublication, TrackPublication } from './track_publication.js';
 import { RemoteTrackPublication } from './track_publication.js';
 import type { ChatMessage } from './types.js';
-import { bigIntToNumber } from './utils.js';
+import {
+  bigIntToNumber,
+  byteStreamInfoFromProto,
+  numberToBigInt,
+  textStreamInfoFromProto,
+} from './utils.js';
 
 export { RoomDataStreamOptions };
 
@@ -104,8 +104,15 @@ export class Room extends (EventEmitter as new () => TypedEmitter<RoomCallbacks>
    */
   private ffiEventLock = new Mutex();
 
-  private byteStreamControllers = new Map<string, StreamController<DataStream_Chunk>>();
-  private textStreamControllers = new Map<string, StreamController<DataStream_Chunk>>();
+  // Active incoming stream readers keyed by their FFI reader handle id. Each entry
+  // owns the FfiClient listener feeding reader events into the ReadableStream.
+  private streamReaders = new Map<
+    bigint,
+    {
+      controller: ReadableStreamDefaultController<DataStream_Chunk>;
+      listener: (ev: FfiEvent) => void;
+    }
+  >();
   private byteStreamHandlers = new Map<string, ByteStreamHandler>();
   private textStreamHandlers = new Map<string, TextStreamHandler>();
 
@@ -445,28 +452,20 @@ export class Room extends (EventEmitter as new () => TypedEmitter<RoomCallbacks>
     if (this.hasCleanedUp) return;
     this.hasCleanedUp = true;
 
-    // Error all in-progress stream controllers to prevent FD leaks.
-    // Streams that were receiving data but never got a trailer (e.g. the sender
-    // disconnected mid-transfer) would otherwise keep their ReadableStream open
-    // indefinitely, leaking the underlying controller and any buffered chunks.
+    // Error all in-progress stream readers to prevent FD leaks.
+    // Streams that were receiving data but never reached end-of-stream (e.g. the
+    // sender disconnected mid-transfer) would otherwise keep their ReadableStream
+    // open indefinitely, leaking the underlying controller and any buffered chunks.
     // Using error() instead of close() signals an abnormal termination to consumers.
-    for (const [, streamController] of this.byteStreamControllers) {
+    for (const [, { controller, listener }] of this.streamReaders) {
+      FfiClient.instance.off(FfiClientEvent.FfiEvent, listener);
       try {
-        streamController.controller.error(new Error('Disconnected while receiving'));
+        controller.error(new Error('Disconnected while receiving'));
       } catch {
         // controller may already be closed or errored
       }
     }
-    this.byteStreamControllers.clear();
-
-    for (const [, streamController] of this.textStreamControllers) {
-      try {
-        streamController.controller.error(new Error('Disconnected while receiving'));
-      } catch {
-        // controller may already be closed or errored
-      }
-    }
-    this.textStreamControllers.clear();
+    this.streamReaders.clear();
 
     // Detach every track from this room so attached FrameProcessors receive
     // onStreamInfoCleared/onCredentialsCleared and the tokenRefreshed listener
@@ -864,12 +863,10 @@ export class Room extends (EventEmitter as new () => TypedEmitter<RoomCallbacks>
       this.emit(RoomEvent.Reconnected);
     } else if (ev.case == 'roomSidChanged') {
       this.emit(RoomEvent.RoomSidChanged, ev.value.sid!);
-    } else if (ev.case === 'streamHeaderReceived' && ev.value.header) {
-      this.handleStreamHeader(ev.value.header, ev.value.participantIdentity!);
-    } else if (ev.case === 'streamChunkReceived' && ev.value.chunk) {
-      this.handleStreamChunk(ev.value.chunk);
-    } else if (ev.case === 'streamTrailerReceived' && ev.value.trailer) {
-      this.handleStreamTrailer(ev.value.trailer);
+    } else if (ev.case === 'byteStreamOpened' && ev.value.reader) {
+      this.handleByteStreamOpened(ev.value.reader, ev.value.participantIdentity!);
+    } else if (ev.case === 'textStreamOpened' && ev.value.reader) {
+      this.handleTextStreamOpened(ev.value.reader, ev.value.participantIdentity!);
     } else if (ev.case === 'roomUpdated') {
       this.info = ev.value;
       this.emit(RoomEvent.RoomUpdated);
@@ -954,104 +951,125 @@ export class Room extends (EventEmitter as new () => TypedEmitter<RoomCallbacks>
     return participant;
   }
 
-  private handleStreamHeader(streamHeader: DataStream_Header, participantIdentity: string) {
-    if (streamHeader.contentHeader.case === 'byteHeader') {
-      const streamHandlerCallback = this.byteStreamHandlers.get(streamHeader.topic ?? '');
+  private handleByteStreamOpened(ownedReader: OwnedByteStreamReader, participantIdentity: string) {
+    const info = byteStreamInfoFromProto(ownedReader.info!);
+    const readerHandle = ownedReader.handle!.id!;
 
-      if (!streamHandlerCallback) {
-        log.debug(
-          'ignoring incoming byte stream due to no handler for topic: %s',
-          streamHeader.topic ?? 'undefined',
-        );
-        return;
-      }
-      let streamController: ReadableStreamDefaultController<DataStream_Chunk>;
-      const stream = new ReadableStream({
-        start: (controller) => {
-          streamController = controller;
-          this.byteStreamControllers.set(streamHeader.streamId!, {
-            header: streamHeader,
-            controller: streamController,
-            startTime: Date.now(),
-          });
-        },
-      });
-      const info: ByteStreamInfo = {
-        streamId: streamHeader.streamId!,
-        name: streamHeader.contentHeader.value.name ?? 'unknown',
-        mimeType: streamHeader.mimeType!,
-        totalSize: streamHeader.totalLength ? Number(streamHeader.totalLength) : undefined,
-        topic: streamHeader.topic!,
-        timestamp: bigIntToNumber(streamHeader.timestamp!),
-        attributes: streamHeader.attributes,
-      };
-      streamHandlerCallback(
-        new ByteStreamReader(info, stream, bigIntToNumber(streamHeader.totalLength)),
-        { identity: participantIdentity },
-      );
-    } else if (streamHeader.contentHeader.case === 'textHeader') {
-      const streamHandlerCallback = this.textStreamHandlers.get(streamHeader.topic ?? '');
-
-      if (!streamHandlerCallback) {
-        log.debug(
-          'ignoring incoming text stream due to no handler for topic: %s',
-          streamHeader.topic ?? 'undefined',
-        );
-        return;
-      }
-      let streamController: ReadableStreamDefaultController<DataStream_Chunk>;
-      const stream = new ReadableStream<DataStream_Chunk>({
-        start: (controller) => {
-          streamController = controller;
-          this.textStreamControllers.set(streamHeader.streamId!, {
-            header: streamHeader,
-            controller: streamController,
-            startTime: Date.now(),
-          });
-        },
-      });
-      const info: TextStreamInfo = {
-        streamId: streamHeader.streamId!,
-        mimeType: streamHeader.mimeType!,
-        totalSize: streamHeader.totalLength ? Number(streamHeader.totalLength) : undefined,
-        topic: streamHeader.topic!,
-        timestamp: Number(streamHeader.timestamp),
-        attributes: streamHeader.attributes,
-      };
-      streamHandlerCallback(
-        new TextStreamReader(info, stream, bigIntToNumber(streamHeader.totalLength)),
-        { identity: participantIdentity },
-      );
+    const streamHandlerCallback = this.byteStreamHandlers.get(info.topic);
+    if (!streamHandlerCallback) {
+      log.debug('ignoring incoming byte stream due to no handler for topic: %s', info.topic);
+      // The native reader was never consumed — dispose it to free the handle
+      // and any chunks it has buffered.
+      new FfiHandle(readerHandle).dispose();
+      return;
     }
+
+    const stream = new ReadableStream<DataStream_Chunk>({
+      start: (controller) => {
+        let nextChunkIndex = 0;
+        const listener = (ev: FfiEvent) => {
+          if (
+            ev.message.case !== 'byteStreamReaderEvent' ||
+            ev.message.value.readerHandle !== readerHandle
+          ) {
+            return;
+          }
+          const detail = ev.message.value.detail;
+          if (detail.case === 'chunkReceived') {
+            const content = detail.value.content!;
+            if (content.length > 0) {
+              controller.enqueue(
+                new DataStream_Chunk({ content, chunkIndex: numberToBigInt(nextChunkIndex++) }),
+              );
+            }
+          } else if (detail.case === 'eos') {
+            // End-of-stream (including a remote abort carrying an error) closes the
+            // stream normally so consumers see EOF, matching the trailer behavior of
+            // the previous implementation.
+            FfiClient.instance.off(FfiClientEvent.FfiEvent, listener);
+            this.streamReaders.delete(readerHandle);
+            controller.close();
+          }
+        };
+        FfiClient.instance.on(FfiClientEvent.FfiEvent, listener);
+        this.streamReaders.set(readerHandle, { controller, listener });
+
+        // Start the incremental read; the native reader buffers chunks received
+        // before this request, so nothing is lost. This consumes the FFI handle.
+        FfiClient.instance.request<ByteStreamReaderReadIncrementalResponse>({
+          message: {
+            case: 'byteReadIncremental',
+            value: new ByteStreamReaderReadIncrementalRequest({ readerHandle }),
+          },
+        });
+      },
+    });
+
+    streamHandlerCallback(
+      new ByteStreamReader(info, stream, bigIntToNumber(ownedReader.info!.totalLength)),
+      { identity: participantIdentity },
+    );
   }
 
-  private handleStreamChunk(chunk: DataStream_Chunk) {
-    const fileBuffer = this.byteStreamControllers.get(chunk.streamId!);
-    if (fileBuffer) {
-      if (chunk.content!.length > 0) {
-        fileBuffer.controller.enqueue(chunk);
-      }
-    }
-    const textBuffer = this.textStreamControllers.get(chunk.streamId!);
-    if (textBuffer) {
-      if (chunk.content!.length > 0) {
-        textBuffer.controller.enqueue(chunk);
-      }
-    }
-  }
+  private handleTextStreamOpened(ownedReader: OwnedTextStreamReader, participantIdentity: string) {
+    const info = textStreamInfoFromProto(ownedReader.info!);
+    const readerHandle = ownedReader.handle!.id!;
 
-  private handleStreamTrailer(trailer: DataStream_Trailer) {
-    const streamId = trailer.streamId!;
-    const fileBuffer = this.byteStreamControllers.get(streamId);
-    if (fileBuffer) {
-      fileBuffer.controller.close();
-      this.byteStreamControllers.delete(streamId);
+    const streamHandlerCallback = this.textStreamHandlers.get(info.topic);
+    if (!streamHandlerCallback) {
+      log.debug('ignoring incoming text stream due to no handler for topic: %s', info.topic);
+      // The native reader was never consumed — dispose it to free the handle
+      // and any chunks it has buffered.
+      new FfiHandle(readerHandle).dispose();
+      return;
     }
-    const textBuffer = this.textStreamControllers.get(streamId);
-    if (textBuffer) {
-      textBuffer.controller.close();
-      this.textStreamControllers.delete(streamId);
-    }
+
+    const textEncoder = new TextEncoder();
+    const stream = new ReadableStream<DataStream_Chunk>({
+      start: (controller) => {
+        let nextChunkIndex = 0;
+        const listener = (ev: FfiEvent) => {
+          if (
+            ev.message.case !== 'textStreamReaderEvent' ||
+            ev.message.value.readerHandle !== readerHandle
+          ) {
+            return;
+          }
+          const detail = ev.message.value.detail;
+          if (detail.case === 'chunkReceived') {
+            const content = textEncoder.encode(detail.value.content!);
+            if (content.length > 0) {
+              controller.enqueue(
+                new DataStream_Chunk({ content, chunkIndex: numberToBigInt(nextChunkIndex++) }),
+              );
+            }
+          } else if (detail.case === 'eos') {
+            // End-of-stream (including a remote abort carrying an error) closes the
+            // stream normally so consumers see EOF, matching the trailer behavior of
+            // the previous implementation.
+            FfiClient.instance.off(FfiClientEvent.FfiEvent, listener);
+            this.streamReaders.delete(readerHandle);
+            controller.close();
+          }
+        };
+        FfiClient.instance.on(FfiClientEvent.FfiEvent, listener);
+        this.streamReaders.set(readerHandle, { controller, listener });
+
+        // Start the incremental read; the native reader buffers chunks received
+        // before this request, so nothing is lost. This consumes the FFI handle.
+        FfiClient.instance.request<TextStreamReaderReadIncrementalResponse>({
+          message: {
+            case: 'textReadIncremental',
+            value: new TextStreamReaderReadIncrementalRequest({ readerHandle }),
+          },
+        });
+      },
+    });
+
+    streamHandlerCallback(
+      new TextStreamReader(info, stream, bigIntToNumber(ownedReader.info!.totalLength)),
+      { identity: participantIdentity },
+    );
   }
 }
 

--- a/packages/livekit-rtc/src/room.ts
+++ b/packages/livekit-rtc/src/room.ts
@@ -967,10 +967,21 @@ export class Room extends (EventEmitter as new () => TypedEmitter<RoomCallbacks>
       return;
     }
 
+    // Assigned by start(); unsubscribe() drops it once the stream is done with,
+    // whether that's end-of-stream or the consumer walking away early.
+    let listener: ((ev: FfiEvent) => void) | null = null;
+    const unsubscribe = () => {
+      if (!listener) {
+        return;
+      }
+      FfiClient.instance.off(FfiClientEvent.FfiEvent, listener);
+      listener = null;
+      this.streamReaders.delete(readerHandle);
+    };
+
     const stream = new ReadableStream<DataStream_Chunk>({
       start: (controller) => {
-        let nextChunkIndex = 0;
-        const listener = (ev: FfiEvent) => {
+        listener = (ev: FfiEvent) => {
           if (
             ev.message.case !== 'byteStreamReaderEvent' ||
             ev.message.value.readerHandle !== readerHandle
@@ -981,13 +992,10 @@ export class Room extends (EventEmitter as new () => TypedEmitter<RoomCallbacks>
           if (detail.case === 'chunkReceived') {
             const content = detail.value.content!;
             if (content.length > 0) {
-              controller.enqueue(
-                new DataStream_Chunk({ content, chunkIndex: numberToBigInt(nextChunkIndex++) }),
-              );
+              controller.enqueue(new DataStream_Chunk({ content }));
             }
           } else if (detail.case === 'eos') {
-            FfiClient.instance.off(FfiClientEvent.FfiEvent, listener);
-            this.streamReaders.delete(readerHandle);
+            unsubscribe();
             const error = detail.value.error;
             if (error) {
               // Abnormal termination (e.g. remote abort, payload over the
@@ -1011,6 +1019,13 @@ export class Room extends (EventEmitter as new () => TypedEmitter<RoomCallbacks>
           },
         });
       },
+      // The consumer stopped reading before end-of-stream — ByteStreamReader
+      // .close(), or breaking out of a for-await. The eos event that would have
+      // unsubscribed is never consumed, so the listener would otherwise be run
+      // against every FFI event for the rest of the process. Only the
+      // subscription is released: the reader handle was consumed by the
+      // readIncremental request above, so there is nothing left to dispose.
+      cancel: () => unsubscribe(),
     });
 
     streamHandlerCallback(
@@ -1033,10 +1048,22 @@ export class Room extends (EventEmitter as new () => TypedEmitter<RoomCallbacks>
     }
 
     const textEncoder = new TextEncoder();
+
+    // Assigned by start(); unsubscribe() drops it once the stream is done with,
+    // whether that's end-of-stream or the consumer walking away early.
+    let listener: ((ev: FfiEvent) => void) | null = null;
+    const unsubscribe = () => {
+      if (!listener) {
+        return;
+      }
+      FfiClient.instance.off(FfiClientEvent.FfiEvent, listener);
+      listener = null;
+      this.streamReaders.delete(readerHandle);
+    };
+
     const stream = new ReadableStream<DataStream_Chunk>({
       start: (controller) => {
-        let nextChunkIndex = 0;
-        const listener = (ev: FfiEvent) => {
+        listener = (ev: FfiEvent) => {
           if (
             ev.message.case !== 'textStreamReaderEvent' ||
             ev.message.value.readerHandle !== readerHandle
@@ -1047,13 +1074,10 @@ export class Room extends (EventEmitter as new () => TypedEmitter<RoomCallbacks>
           if (detail.case === 'chunkReceived') {
             const content = textEncoder.encode(detail.value.content!);
             if (content.length > 0) {
-              controller.enqueue(
-                new DataStream_Chunk({ content, chunkIndex: numberToBigInt(nextChunkIndex++) }),
-              );
+              controller.enqueue(new DataStream_Chunk({ content }));
             }
           } else if (detail.case === 'eos') {
-            FfiClient.instance.off(FfiClientEvent.FfiEvent, listener);
-            this.streamReaders.delete(readerHandle);
+            unsubscribe();
             const error = detail.value.error;
             if (error) {
               // Abnormal termination (e.g. remote abort, payload over the
@@ -1077,6 +1101,13 @@ export class Room extends (EventEmitter as new () => TypedEmitter<RoomCallbacks>
           },
         });
       },
+      // The consumer stopped reading before end-of-stream — TextStreamReader
+      // .close(), or breaking out of a for-await. The eos event that would have
+      // unsubscribed is never consumed, so the listener would otherwise be run
+      // against every FFI event for the rest of the process. Only the
+      // subscription is released: the reader handle was consumed by the
+      // readIncremental request above, so there is nothing left to dispose.
+      cancel: () => unsubscribe(),
     });
 
     streamHandlerCallback(

--- a/packages/livekit-rtc/src/room.ts
+++ b/packages/livekit-rtc/src/room.ts
@@ -75,7 +75,7 @@ export interface RoomDataStreamOptions {
   /**
    * Maximum decompressed payload size in bytes accepted for a single incoming
    * data stream. Incoming streams exceeding this limit terminate with an error
-   * on the receiving side. Unset falls back to the SDK default.
+   * on the receiving side. Unset falls back to the SDK default of 5gb.
    */
   maxPayloadByteLength?: number;
 }

--- a/packages/livekit-rtc/src/room.ts
+++ b/packages/livekit-rtc/src/room.ts
@@ -485,6 +485,11 @@ export class Room extends (EventEmitter as new () => TypedEmitter<RoomCallbacks>
     // listener until GC. setRoom(null) is idempotent, so this is safe even if a
     // track was already detached (e.g. via unsubscribe/unpublish).
     if (this.localParticipant) {
+      // Data stream writers that were never closed (abandoned by the caller, or
+      // left errored by a failed write) keep their native writer alive until
+      // their handle is dropped.
+      this.localParticipant.disposeOpenStreamWriters();
+
       for (const pub of this.localParticipant.trackPublications.values()) {
         pub.track?.setRoom(null);
       }

--- a/packages/livekit-rtc/src/room.ts
+++ b/packages/livekit-rtc/src/room.ts
@@ -22,13 +22,13 @@ import {
   type DataPacketKind,
   DataStream_Chunk,
   type DisconnectResponse,
+  RoomDataStreamOptions as FfiRoomDataStreamOptions,
   RoomOptions as FfiRoomOptions,
   type IceServer,
   IceTransportType,
   type OwnedByteStreamReader,
   type OwnedTextStreamReader,
   type ReadyForRoomEventResponse,
-  RoomDataStreamOptions,
   type RoomInfo,
   type SimulateScenarioCallback,
   type SimulateScenarioKind,
@@ -59,8 +59,6 @@ import {
   textStreamInfoFromProto,
 } from './utils.js';
 
-export { RoomDataStreamOptions };
-
 export interface RtcConfiguration {
   iceTransportType: IceTransportType;
   continualGatheringPolicy: ContinualGatheringPolicy;
@@ -73,6 +71,15 @@ export const defaultRtcConfiguration: RtcConfiguration = {
   iceServers: [],
 };
 
+export interface RoomDataStreamOptions {
+  /**
+   * Maximum decompressed payload size in bytes accepted for a single incoming
+   * data stream. Incoming streams exceeding this limit terminate with an error
+   * on the receiving side. Unset falls back to the SDK default.
+   */
+  maxPayloadByteLength?: number;
+}
+
 export interface RoomOptions {
   autoSubscribe: boolean;
   dynacast: boolean;
@@ -82,6 +89,8 @@ export interface RoomOptions {
   e2ee?: E2EEOptions;
   encryption?: E2EEOptions;
   rtcConfig?: RtcConfiguration;
+  /** Options controlling data stream behavior for this room. */
+  dataStream?: RoomDataStreamOptions;
 }
 
 export const defaultRoomOptions = new FfiRoomOptions({
@@ -282,14 +291,10 @@ export class Room extends (EventEmitter as new () => TypedEmitter<RoomCallbacks>
    * @throws ConnectError - if connection fails
    */
   async connect(url: string, token: string, opts?: RoomOptions) {
-    const options = { ...defaultRoomOptions, ...opts };
-    // The Node SDK still implements data streams in TypeScript on top of raw FFI
-    // packets, so always advertise only legacy (v1) data stream support to other
-    // clients, preserving any other data stream options provided by the user.
-    options.dataStream = new RoomDataStreamOptions({
-      ...options.dataStream,
-      useLegacyClientImplementation: true,
-    });
+    // dataStream is a plain user-facing object; convert it to its proto
+    // message separately instead of spreading it into the FFI options.
+    const { dataStream, ...restOpts } = opts ?? {};
+    const options = { ...defaultRoomOptions, ...restOpts };
     const e2eeEnabled = options.encryption || options.e2ee;
     const userE2EEOptions = options.encryption ?? options.e2ee;
     const e2eeOptions: E2EEOptions = {
@@ -307,6 +312,12 @@ export class Room extends (EventEmitter as new () => TypedEmitter<RoomCallbacks>
       mergedOptions.encryption = e2eeOptions;
     } else if (options.e2ee) {
       mergedOptions.e2ee = e2eeOptions;
+    }
+
+    if (dataStream) {
+      mergedOptions.dataStream = new FfiRoomDataStreamOptions({
+        maxPayloadByteLength: numberToBigInt(dataStream.maxPayloadByteLength),
+      });
     }
 
     const req = new ConnectRequest({

--- a/packages/livekit-rtc/src/room.ts
+++ b/packages/livekit-rtc/src/room.ts
@@ -22,13 +22,13 @@ import {
   type DataPacketKind,
   DataStream_Chunk,
   type DisconnectResponse,
+  RoomDataStreamOptions as FfiRoomDataStreamOptions,
   RoomOptions as FfiRoomOptions,
   type IceServer,
   IceTransportType,
   type OwnedByteStreamReader,
   type OwnedTextStreamReader,
   type ReadyForRoomEventResponse,
-  RoomDataStreamOptions,
   type RoomInfo,
   type SimulateScenarioCallback,
   type SimulateScenarioKind,
@@ -59,8 +59,6 @@ import {
   textStreamInfoFromProto,
 } from './utils.js';
 
-export { RoomDataStreamOptions };
-
 export interface RtcConfiguration {
   iceTransportType: IceTransportType;
   continualGatheringPolicy: ContinualGatheringPolicy;
@@ -73,6 +71,15 @@ export const defaultRtcConfiguration: RtcConfiguration = {
   iceServers: [],
 };
 
+export interface RoomDataStreamOptions {
+  /**
+   * Maximum decompressed payload size in bytes accepted for a single incoming
+   * data stream. Incoming streams exceeding this limit terminate with an error
+   * on the receiving side. Unset falls back to the SDK default.
+   */
+  maxPayloadByteLength?: number;
+}
+
 export interface RoomOptions {
   autoSubscribe: boolean;
   dynacast: boolean;
@@ -82,6 +89,8 @@ export interface RoomOptions {
   e2ee?: E2EEOptions;
   encryption?: E2EEOptions;
   rtcConfig?: RtcConfiguration;
+  /** Options controlling data stream behavior for this room. */
+  dataStream?: RoomDataStreamOptions;
 }
 
 export const defaultRoomOptions = new FfiRoomOptions({
@@ -282,14 +291,10 @@ export class Room extends (EventEmitter as new () => TypedEmitter<RoomCallbacks>
    * @throws ConnectError - if connection fails
    */
   async connect(url: string, token: string, opts?: RoomOptions) {
-    const options = { ...defaultRoomOptions, ...opts };
-    // The Node SDK still implements data streams in TypeScript on top of raw FFI
-    // packets, so always advertise only legacy (v1) data stream support to other
-    // clients, preserving any other data stream options provided by the user.
-    options.dataStream = new RoomDataStreamOptions({
-      ...options.dataStream,
-      useLegacyClientImplementation: true,
-    });
+    // dataStream is a plain user-facing object; convert it to its proto
+    // message separately instead of spreading it into the FFI options.
+    const { dataStream, ...restOpts } = opts ?? {};
+    const options = { ...defaultRoomOptions, ...restOpts };
     const e2eeEnabled = options.encryption || options.e2ee;
     const e2eeOptions = options.encryption
       ? { ...defaultE2EEOptions, ...options.encryption }
@@ -298,7 +303,14 @@ export class Room extends (EventEmitter as new () => TypedEmitter<RoomCallbacks>
     const req = new ConnectRequest({
       url: url,
       token: token,
-      options,
+      options: {
+        ...options,
+        dataStream: dataStream
+          ? new FfiRoomDataStreamOptions({
+              maxPayloadByteLength: numberToBigInt(dataStream.maxPayloadByteLength),
+            })
+          : undefined,
+      },
     });
 
     FfiClient.instance.on(FfiClientEvent.FfiEvent, this.onFfiEvent);

--- a/packages/livekit-rtc/src/room.ts
+++ b/packages/livekit-rtc/src/room.ts
@@ -980,10 +980,21 @@ export class Room extends (EventEmitter as new () => TypedEmitter<RoomCallbacks>
       return;
     }
 
+    // Assigned by start(); unsubscribe() drops it once the stream is done with,
+    // whether that's end-of-stream or the consumer walking away early.
+    let listener: ((ev: FfiEvent) => void) | null = null;
+    const unsubscribe = () => {
+      if (!listener) {
+        return;
+      }
+      FfiClient.instance.off(FfiClientEvent.FfiEvent, listener);
+      listener = null;
+      this.streamReaders.delete(readerHandle);
+    };
+
     const stream = new ReadableStream<DataStream_Chunk>({
       start: (controller) => {
-        let nextChunkIndex = 0;
-        const listener = (ev: FfiEvent) => {
+        listener = (ev: FfiEvent) => {
           if (
             ev.message.case !== 'byteStreamReaderEvent' ||
             ev.message.value.readerHandle !== readerHandle
@@ -994,13 +1005,10 @@ export class Room extends (EventEmitter as new () => TypedEmitter<RoomCallbacks>
           if (detail.case === 'chunkReceived') {
             const content = detail.value.content!;
             if (content.length > 0) {
-              controller.enqueue(
-                new DataStream_Chunk({ content, chunkIndex: numberToBigInt(nextChunkIndex++) }),
-              );
+              controller.enqueue(new DataStream_Chunk({ content }));
             }
           } else if (detail.case === 'eos') {
-            FfiClient.instance.off(FfiClientEvent.FfiEvent, listener);
-            this.streamReaders.delete(readerHandle);
+            unsubscribe();
             const error = detail.value.error;
             if (error) {
               // Abnormal termination (e.g. remote abort, payload over the
@@ -1024,6 +1032,13 @@ export class Room extends (EventEmitter as new () => TypedEmitter<RoomCallbacks>
           },
         });
       },
+      // The consumer stopped reading before end-of-stream — ByteStreamReader
+      // .close(), or breaking out of a for-await. The eos event that would have
+      // unsubscribed is never consumed, so the listener would otherwise be run
+      // against every FFI event for the rest of the process. Only the
+      // subscription is released: the reader handle was consumed by the
+      // readIncremental request above, so there is nothing left to dispose.
+      cancel: () => unsubscribe(),
     });
 
     streamHandlerCallback(
@@ -1046,10 +1061,22 @@ export class Room extends (EventEmitter as new () => TypedEmitter<RoomCallbacks>
     }
 
     const textEncoder = new TextEncoder();
+
+    // Assigned by start(); unsubscribe() drops it once the stream is done with,
+    // whether that's end-of-stream or the consumer walking away early.
+    let listener: ((ev: FfiEvent) => void) | null = null;
+    const unsubscribe = () => {
+      if (!listener) {
+        return;
+      }
+      FfiClient.instance.off(FfiClientEvent.FfiEvent, listener);
+      listener = null;
+      this.streamReaders.delete(readerHandle);
+    };
+
     const stream = new ReadableStream<DataStream_Chunk>({
       start: (controller) => {
-        let nextChunkIndex = 0;
-        const listener = (ev: FfiEvent) => {
+        listener = (ev: FfiEvent) => {
           if (
             ev.message.case !== 'textStreamReaderEvent' ||
             ev.message.value.readerHandle !== readerHandle
@@ -1060,13 +1087,10 @@ export class Room extends (EventEmitter as new () => TypedEmitter<RoomCallbacks>
           if (detail.case === 'chunkReceived') {
             const content = textEncoder.encode(detail.value.content!);
             if (content.length > 0) {
-              controller.enqueue(
-                new DataStream_Chunk({ content, chunkIndex: numberToBigInt(nextChunkIndex++) }),
-              );
+              controller.enqueue(new DataStream_Chunk({ content }));
             }
           } else if (detail.case === 'eos') {
-            FfiClient.instance.off(FfiClientEvent.FfiEvent, listener);
-            this.streamReaders.delete(readerHandle);
+            unsubscribe();
             const error = detail.value.error;
             if (error) {
               // Abnormal termination (e.g. remote abort, payload over the
@@ -1090,6 +1114,13 @@ export class Room extends (EventEmitter as new () => TypedEmitter<RoomCallbacks>
           },
         });
       },
+      // The consumer stopped reading before end-of-stream — TextStreamReader
+      // .close(), or breaking out of a for-await. The eos event that would have
+      // unsubscribed is never consumed, so the listener would otherwise be run
+      // against every FFI event for the rest of the process. Only the
+      // subscription is released: the reader handle was consumed by the
+      // readIncremental request above, so there is nothing left to dispose.
+      cancel: () => unsubscribe(),
     });
 
     streamHandlerCallback(

--- a/packages/livekit-rtc/src/room.ts
+++ b/packages/livekit-rtc/src/room.ts
@@ -472,6 +472,11 @@ export class Room extends (EventEmitter as new () => TypedEmitter<RoomCallbacks>
     // listener until GC. setRoom(null) is idempotent, so this is safe even if a
     // track was already detached (e.g. via unsubscribe/unpublish).
     if (this.localParticipant) {
+      // Data stream writers that were never closed (abandoned by the caller, or
+      // left errored by a failed write) keep their native writer alive until
+      // their handle is dropped.
+      this.localParticipant.disposeOpenStreamWriters();
+
       for (const pub of this.localParticipant.trackPublications.values()) {
         pub.track?.setRoom(null);
       }

--- a/packages/livekit-rtc/src/room.ts
+++ b/packages/livekit-rtc/src/room.ts
@@ -9,12 +9,10 @@ import type {
   GetSessionStatsResponse,
 } from '@livekit/rtc-ffi-bindings';
 import { DisconnectReason, type OwnedParticipant } from '@livekit/rtc-ffi-bindings';
-import type {
-  DataStream_Trailer,
-  DisconnectCallback,
-  TrackPublicationInfo,
-} from '@livekit/rtc-ffi-bindings';
+import { type DisconnectCallback, type TrackPublicationInfo } from '@livekit/rtc-ffi-bindings';
 import {
+  ByteStreamReaderReadIncrementalRequest,
+  type ByteStreamReaderReadIncrementalResponse,
   type ConnectCallback,
   ConnectRequest,
   type ConnectResponse,
@@ -22,30 +20,27 @@ import {
   ConnectionState,
   ContinualGatheringPolicy,
   type DataPacketKind,
-  type DataStream_Chunk,
-  type DataStream_Header,
+  DataStream_Chunk,
   type DisconnectResponse,
   RoomOptions as FfiRoomOptions,
   type IceServer,
   IceTransportType,
+  type OwnedByteStreamReader,
+  type OwnedTextStreamReader,
   type ReadyForRoomEventResponse,
   RoomDataStreamOptions,
   type RoomInfo,
   type SimulateScenarioCallback,
   type SimulateScenarioKind,
   type SimulateScenarioResponse,
+  TextStreamReaderReadIncrementalRequest,
+  type TextStreamReaderReadIncrementalResponse,
 } from '@livekit/rtc-ffi-bindings';
 import { TrackKind } from '@livekit/rtc-ffi-bindings';
 import type { TypedEventEmitter as TypedEmitter } from '@livekit/typed-emitter';
 import EventEmitter from 'events';
 import { ByteStreamReader, TextStreamReader } from './data_streams/stream_reader.js';
-import type {
-  ByteStreamHandler,
-  ByteStreamInfo,
-  StreamController,
-  TextStreamHandler,
-  TextStreamInfo,
-} from './data_streams/types.js';
+import { type ByteStreamHandler, type TextStreamHandler } from './data_streams/types.js';
 import type { E2EEOptions } from './e2ee.js';
 import { E2EEManager, defaultE2EEOptions } from './e2ee.js';
 import { FfiClient, FfiClientEvent, FfiHandle } from './ffi_client.js';
@@ -57,7 +52,12 @@ import { RemoteAudioTrack, RemoteVideoTrack } from './track.js';
 import type { LocalTrackPublication, TrackPublication } from './track_publication.js';
 import { RemoteTrackPublication } from './track_publication.js';
 import type { ChatMessage } from './types.js';
-import { bigIntToNumber } from './utils.js';
+import {
+  bigIntToNumber,
+  byteStreamInfoFromProto,
+  numberToBigInt,
+  textStreamInfoFromProto,
+} from './utils.js';
 
 export { RoomDataStreamOptions };
 
@@ -104,8 +104,15 @@ export class Room extends (EventEmitter as new () => TypedEmitter<RoomCallbacks>
    */
   private ffiEventLock = new Mutex();
 
-  private byteStreamControllers = new Map<string, StreamController<DataStream_Chunk>>();
-  private textStreamControllers = new Map<string, StreamController<DataStream_Chunk>>();
+  // Active incoming stream readers keyed by their FFI reader handle id. Each entry
+  // owns the FfiClient listener feeding reader events into the ReadableStream.
+  private streamReaders = new Map<
+    bigint,
+    {
+      controller: ReadableStreamDefaultController<DataStream_Chunk>;
+      listener: (ev: FfiEvent) => void;
+    }
+  >();
   private byteStreamHandlers = new Map<string, ByteStreamHandler>();
   private textStreamHandlers = new Map<string, TextStreamHandler>();
 
@@ -431,28 +438,20 @@ export class Room extends (EventEmitter as new () => TypedEmitter<RoomCallbacks>
     if (this.hasCleanedUp) return;
     this.hasCleanedUp = true;
 
-    // Error all in-progress stream controllers to prevent FD leaks.
-    // Streams that were receiving data but never got a trailer (e.g. the sender
-    // disconnected mid-transfer) would otherwise keep their ReadableStream open
-    // indefinitely, leaking the underlying controller and any buffered chunks.
+    // Error all in-progress stream readers to prevent FD leaks.
+    // Streams that were receiving data but never reached end-of-stream (e.g. the
+    // sender disconnected mid-transfer) would otherwise keep their ReadableStream
+    // open indefinitely, leaking the underlying controller and any buffered chunks.
     // Using error() instead of close() signals an abnormal termination to consumers.
-    for (const [, streamController] of this.byteStreamControllers) {
+    for (const [, { controller, listener }] of this.streamReaders) {
+      FfiClient.instance.off(FfiClientEvent.FfiEvent, listener);
       try {
-        streamController.controller.error(new Error('Disconnected while receiving'));
+        controller.error(new Error('Disconnected while receiving'));
       } catch {
         // controller may already be closed or errored
       }
     }
-    this.byteStreamControllers.clear();
-
-    for (const [, streamController] of this.textStreamControllers) {
-      try {
-        streamController.controller.error(new Error('Disconnected while receiving'));
-      } catch {
-        // controller may already be closed or errored
-      }
-    }
-    this.textStreamControllers.clear();
+    this.streamReaders.clear();
 
     // Detach every track from this room so attached FrameProcessors receive
     // onStreamInfoCleared/onCredentialsCleared and the tokenRefreshed listener
@@ -850,12 +849,10 @@ export class Room extends (EventEmitter as new () => TypedEmitter<RoomCallbacks>
       this.emit(RoomEvent.Reconnected);
     } else if (ev.case == 'roomSidChanged') {
       this.emit(RoomEvent.RoomSidChanged, ev.value.sid!);
-    } else if (ev.case === 'streamHeaderReceived' && ev.value.header) {
-      this.handleStreamHeader(ev.value.header, ev.value.participantIdentity!);
-    } else if (ev.case === 'streamChunkReceived' && ev.value.chunk) {
-      this.handleStreamChunk(ev.value.chunk);
-    } else if (ev.case === 'streamTrailerReceived' && ev.value.trailer) {
-      this.handleStreamTrailer(ev.value.trailer);
+    } else if (ev.case === 'byteStreamOpened' && ev.value.reader) {
+      this.handleByteStreamOpened(ev.value.reader, ev.value.participantIdentity!);
+    } else if (ev.case === 'textStreamOpened' && ev.value.reader) {
+      this.handleTextStreamOpened(ev.value.reader, ev.value.participantIdentity!);
     } else if (ev.case === 'roomUpdated') {
       this.info = ev.value;
       this.emit(RoomEvent.RoomUpdated);
@@ -940,104 +937,125 @@ export class Room extends (EventEmitter as new () => TypedEmitter<RoomCallbacks>
     return participant;
   }
 
-  private handleStreamHeader(streamHeader: DataStream_Header, participantIdentity: string) {
-    if (streamHeader.contentHeader.case === 'byteHeader') {
-      const streamHandlerCallback = this.byteStreamHandlers.get(streamHeader.topic ?? '');
+  private handleByteStreamOpened(ownedReader: OwnedByteStreamReader, participantIdentity: string) {
+    const info = byteStreamInfoFromProto(ownedReader.info!);
+    const readerHandle = ownedReader.handle!.id!;
 
-      if (!streamHandlerCallback) {
-        log.debug(
-          'ignoring incoming byte stream due to no handler for topic: %s',
-          streamHeader.topic ?? 'undefined',
-        );
-        return;
-      }
-      let streamController: ReadableStreamDefaultController<DataStream_Chunk>;
-      const stream = new ReadableStream({
-        start: (controller) => {
-          streamController = controller;
-          this.byteStreamControllers.set(streamHeader.streamId!, {
-            header: streamHeader,
-            controller: streamController,
-            startTime: Date.now(),
-          });
-        },
-      });
-      const info: ByteStreamInfo = {
-        streamId: streamHeader.streamId!,
-        name: streamHeader.contentHeader.value.name ?? 'unknown',
-        mimeType: streamHeader.mimeType!,
-        totalSize: streamHeader.totalLength ? Number(streamHeader.totalLength) : undefined,
-        topic: streamHeader.topic!,
-        timestamp: bigIntToNumber(streamHeader.timestamp!),
-        attributes: streamHeader.attributes,
-      };
-      streamHandlerCallback(
-        new ByteStreamReader(info, stream, bigIntToNumber(streamHeader.totalLength)),
-        { identity: participantIdentity },
-      );
-    } else if (streamHeader.contentHeader.case === 'textHeader') {
-      const streamHandlerCallback = this.textStreamHandlers.get(streamHeader.topic ?? '');
-
-      if (!streamHandlerCallback) {
-        log.debug(
-          'ignoring incoming text stream due to no handler for topic: %s',
-          streamHeader.topic ?? 'undefined',
-        );
-        return;
-      }
-      let streamController: ReadableStreamDefaultController<DataStream_Chunk>;
-      const stream = new ReadableStream<DataStream_Chunk>({
-        start: (controller) => {
-          streamController = controller;
-          this.textStreamControllers.set(streamHeader.streamId!, {
-            header: streamHeader,
-            controller: streamController,
-            startTime: Date.now(),
-          });
-        },
-      });
-      const info: TextStreamInfo = {
-        streamId: streamHeader.streamId!,
-        mimeType: streamHeader.mimeType!,
-        totalSize: streamHeader.totalLength ? Number(streamHeader.totalLength) : undefined,
-        topic: streamHeader.topic!,
-        timestamp: Number(streamHeader.timestamp),
-        attributes: streamHeader.attributes,
-      };
-      streamHandlerCallback(
-        new TextStreamReader(info, stream, bigIntToNumber(streamHeader.totalLength)),
-        { identity: participantIdentity },
-      );
+    const streamHandlerCallback = this.byteStreamHandlers.get(info.topic);
+    if (!streamHandlerCallback) {
+      log.debug('ignoring incoming byte stream due to no handler for topic: %s', info.topic);
+      // The native reader was never consumed — dispose it to free the handle
+      // and any chunks it has buffered.
+      new FfiHandle(readerHandle).dispose();
+      return;
     }
+
+    const stream = new ReadableStream<DataStream_Chunk>({
+      start: (controller) => {
+        let nextChunkIndex = 0;
+        const listener = (ev: FfiEvent) => {
+          if (
+            ev.message.case !== 'byteStreamReaderEvent' ||
+            ev.message.value.readerHandle !== readerHandle
+          ) {
+            return;
+          }
+          const detail = ev.message.value.detail;
+          if (detail.case === 'chunkReceived') {
+            const content = detail.value.content!;
+            if (content.length > 0) {
+              controller.enqueue(
+                new DataStream_Chunk({ content, chunkIndex: numberToBigInt(nextChunkIndex++) }),
+              );
+            }
+          } else if (detail.case === 'eos') {
+            // End-of-stream (including a remote abort carrying an error) closes the
+            // stream normally so consumers see EOF, matching the trailer behavior of
+            // the previous implementation.
+            FfiClient.instance.off(FfiClientEvent.FfiEvent, listener);
+            this.streamReaders.delete(readerHandle);
+            controller.close();
+          }
+        };
+        FfiClient.instance.on(FfiClientEvent.FfiEvent, listener);
+        this.streamReaders.set(readerHandle, { controller, listener });
+
+        // Start the incremental read; the native reader buffers chunks received
+        // before this request, so nothing is lost. This consumes the FFI handle.
+        FfiClient.instance.request<ByteStreamReaderReadIncrementalResponse>({
+          message: {
+            case: 'byteReadIncremental',
+            value: new ByteStreamReaderReadIncrementalRequest({ readerHandle }),
+          },
+        });
+      },
+    });
+
+    streamHandlerCallback(
+      new ByteStreamReader(info, stream, bigIntToNumber(ownedReader.info!.totalLength)),
+      { identity: participantIdentity },
+    );
   }
 
-  private handleStreamChunk(chunk: DataStream_Chunk) {
-    const fileBuffer = this.byteStreamControllers.get(chunk.streamId!);
-    if (fileBuffer) {
-      if (chunk.content!.length > 0) {
-        fileBuffer.controller.enqueue(chunk);
-      }
-    }
-    const textBuffer = this.textStreamControllers.get(chunk.streamId!);
-    if (textBuffer) {
-      if (chunk.content!.length > 0) {
-        textBuffer.controller.enqueue(chunk);
-      }
-    }
-  }
+  private handleTextStreamOpened(ownedReader: OwnedTextStreamReader, participantIdentity: string) {
+    const info = textStreamInfoFromProto(ownedReader.info!);
+    const readerHandle = ownedReader.handle!.id!;
 
-  private handleStreamTrailer(trailer: DataStream_Trailer) {
-    const streamId = trailer.streamId!;
-    const fileBuffer = this.byteStreamControllers.get(streamId);
-    if (fileBuffer) {
-      fileBuffer.controller.close();
-      this.byteStreamControllers.delete(streamId);
+    const streamHandlerCallback = this.textStreamHandlers.get(info.topic);
+    if (!streamHandlerCallback) {
+      log.debug('ignoring incoming text stream due to no handler for topic: %s', info.topic);
+      // The native reader was never consumed — dispose it to free the handle
+      // and any chunks it has buffered.
+      new FfiHandle(readerHandle).dispose();
+      return;
     }
-    const textBuffer = this.textStreamControllers.get(streamId);
-    if (textBuffer) {
-      textBuffer.controller.close();
-      this.textStreamControllers.delete(streamId);
-    }
+
+    const textEncoder = new TextEncoder();
+    const stream = new ReadableStream<DataStream_Chunk>({
+      start: (controller) => {
+        let nextChunkIndex = 0;
+        const listener = (ev: FfiEvent) => {
+          if (
+            ev.message.case !== 'textStreamReaderEvent' ||
+            ev.message.value.readerHandle !== readerHandle
+          ) {
+            return;
+          }
+          const detail = ev.message.value.detail;
+          if (detail.case === 'chunkReceived') {
+            const content = textEncoder.encode(detail.value.content!);
+            if (content.length > 0) {
+              controller.enqueue(
+                new DataStream_Chunk({ content, chunkIndex: numberToBigInt(nextChunkIndex++) }),
+              );
+            }
+          } else if (detail.case === 'eos') {
+            // End-of-stream (including a remote abort carrying an error) closes the
+            // stream normally so consumers see EOF, matching the trailer behavior of
+            // the previous implementation.
+            FfiClient.instance.off(FfiClientEvent.FfiEvent, listener);
+            this.streamReaders.delete(readerHandle);
+            controller.close();
+          }
+        };
+        FfiClient.instance.on(FfiClientEvent.FfiEvent, listener);
+        this.streamReaders.set(readerHandle, { controller, listener });
+
+        // Start the incremental read; the native reader buffers chunks received
+        // before this request, so nothing is lost. This consumes the FFI handle.
+        FfiClient.instance.request<TextStreamReaderReadIncrementalResponse>({
+          message: {
+            case: 'textReadIncremental',
+            value: new TextStreamReaderReadIncrementalRequest({ readerHandle }),
+          },
+        });
+      },
+    });
+
+    streamHandlerCallback(
+      new TextStreamReader(info, stream, bigIntToNumber(ownedReader.info!.totalLength)),
+      { identity: participantIdentity },
+    );
   }
 }
 

--- a/packages/livekit-rtc/src/room.ts
+++ b/packages/livekit-rtc/src/room.ts
@@ -994,12 +994,17 @@ export class Room extends (EventEmitter as new () => TypedEmitter<RoomCallbacks>
               );
             }
           } else if (detail.case === 'eos') {
-            // End-of-stream (including a remote abort carrying an error) closes the
-            // stream normally so consumers see EOF, matching the trailer behavior of
-            // the previous implementation.
             FfiClient.instance.off(FfiClientEvent.FfiEvent, listener);
             this.streamReaders.delete(readerHandle);
-            controller.close();
+            const error = detail.value.error;
+            if (error) {
+              // Abnormal termination (e.g. remote abort, payload over the
+              // receiver's size limit): surface the error to the consumer
+              // instead of presenting a truncated payload as a clean EOF.
+              controller.error(new Error(error.description ?? 'stream terminated'));
+            } else {
+              controller.close();
+            }
           }
         };
         FfiClient.instance.on(FfiClientEvent.FfiEvent, listener);
@@ -1055,12 +1060,17 @@ export class Room extends (EventEmitter as new () => TypedEmitter<RoomCallbacks>
               );
             }
           } else if (detail.case === 'eos') {
-            // End-of-stream (including a remote abort carrying an error) closes the
-            // stream normally so consumers see EOF, matching the trailer behavior of
-            // the previous implementation.
             FfiClient.instance.off(FfiClientEvent.FfiEvent, listener);
             this.streamReaders.delete(readerHandle);
-            controller.close();
+            const error = detail.value.error;
+            if (error) {
+              // Abnormal termination (e.g. remote abort, payload over the
+              // receiver's size limit): surface the error to the consumer
+              // instead of presenting a truncated payload as a clean EOF.
+              controller.error(new Error(error.description ?? 'stream terminated'));
+            } else {
+              controller.close();
+            }
           }
         };
         FfiClient.instance.on(FfiClientEvent.FfiEvent, listener);

--- a/packages/livekit-rtc/src/tests/e2e.test.ts
+++ b/packages/livekit-rtc/src/tests/e2e.test.ts
@@ -1,10 +1,8 @@
 // SPDX-FileCopyrightText: 2026 LiveKit, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
-import { AccessToken } from 'livekit-server-sdk';
-import { randomUUID } from 'node:crypto';
 import { setTimeout as delay } from 'node:timers/promises';
-import { afterAll, describe, expect, it as itRaw } from 'vitest';
+import { afterAll, expect, it as itRaw } from 'vitest';
 import {
   AudioFrame,
   AudioSource,
@@ -12,9 +10,7 @@ import {
   ConnectionState,
   LocalAudioTrack,
   ParticipantKind,
-  Room,
   RoomEvent,
-  type RoomOptions,
   RpcError,
   SimulateScenarioKind,
   TrackKind,
@@ -22,140 +18,18 @@ import {
   TrackSource,
   dispose,
 } from '../index.js';
+import {
+  concatUint8,
+  connectTestRooms,
+  describeE2E,
+  testTimeoutMs,
+  waitFor,
+  waitForRoomEvent,
+  withTimeout,
+} from './e2e_common.js';
 
 // use concurrent testing if available on the runner (currently not supported by bun's api)
 const it = typeof itRaw.concurrent === 'function' ? itRaw.concurrent : itRaw;
-
-const hasE2EEnv =
-  !!process.env.LIVEKIT_URL && !!process.env.LIVEKIT_API_KEY && !!process.env.LIVEKIT_API_SECRET;
-const describeE2E = hasE2EEnv ? describe : describe.skip;
-const testTimeoutMs = 10_000;
-
-type TestEnv = {
-  url: string;
-  apiKey: string;
-  apiSecret: string;
-};
-
-function normalizeLiveKitUrl(url: string): string {
-  if (url.startsWith('http://')) return `ws://${url.slice('http://'.length)}`;
-  if (url.startsWith('https://')) return `wss://${url.slice('https://'.length)}`;
-  return url;
-}
-
-function getTestEnv(): TestEnv {
-  if (!hasE2EEnv) {
-    throw new Error(
-      'Missing required env vars for e2e: LIVEKIT_URL, LIVEKIT_API_KEY, LIVEKIT_API_SECRET',
-    );
-  }
-  return {
-    url: normalizeLiveKitUrl(process.env.LIVEKIT_URL!),
-    apiKey: process.env.LIVEKIT_API_KEY!,
-    apiSecret: process.env.LIVEKIT_API_SECRET!,
-  };
-}
-
-async function withTimeout<T>(promise: Promise<T>, timeoutMs: number, message: string): Promise<T> {
-  return await Promise.race([
-    promise,
-    (async () => {
-      await delay(timeoutMs);
-      throw new Error(message);
-    })(),
-  ]);
-}
-
-async function waitFor(
-  condition: () => boolean,
-  opts: { timeoutMs: number; intervalMs?: number; debugName?: string },
-): Promise<void> {
-  const intervalMs = opts.intervalMs ?? 50;
-  const deadline = Date.now() + opts.timeoutMs;
-  while (Date.now() < deadline) {
-    if (condition()) return;
-    await delay(intervalMs);
-  }
-  throw new Error(`Timed out waiting for condition${opts.debugName ? ` (${opts.debugName})` : ''}`);
-}
-
-async function createJoinToken(params: {
-  env: TestEnv;
-  roomName: string;
-  identity: string;
-  name: string;
-}): Promise<string> {
-  const token = new AccessToken(params.env.apiKey, params.env.apiSecret, {
-    identity: params.identity,
-    name: params.name,
-    ttl: '30m',
-  });
-  token.addGrant({
-    room: params.roomName,
-    roomJoin: true,
-    roomCreate: true,
-    canPublish: true,
-    canSubscribe: true,
-  });
-  return await token.toJwt();
-}
-
-async function connectTestRooms(
-  count: number,
-  extraOptions?: Partial<RoomOptions>,
-): Promise<{ roomName: string; rooms: Room[] }> {
-  const env = getTestEnv();
-  const roomName = `test_room_${randomUUID()}`;
-  const rooms = await Promise.all(
-    Array.from({ length: count }, async (_, i) => {
-      const token = await createJoinToken({
-        env,
-        roomName,
-        identity: `p${i}`,
-        name: `Participant ${i}`,
-      });
-      const room = new Room();
-      await room.connect(env.url, token, {
-        autoSubscribe: true,
-        dynacast: false,
-        ...extraOptions,
-      });
-      return room;
-    }),
-  );
-
-  const start = Date.now();
-  await waitFor(() => rooms.every((r) => r.remoteParticipants.size === count - 1), {
-    timeoutMs: 5000,
-    debugName: `participant visibility (${Date.now() - start}ms)`,
-  });
-
-  return { roomName, rooms };
-}
-
-function waitForRoomEvent<R>(
-  room: Room,
-  event: RoomEvent,
-  timeoutMs: number,
-  take: (...args: any[]) => R,
-  match?: (...args: unknown[]) => boolean,
-): Promise<R> {
-  return withTimeout(
-    new Promise<R>((resolve) => {
-      const handler = (...args: any[]) => {
-        if (match && !match(...args)) {
-          return;
-        }
-        // typed-emitter doesn't expose `.once` in the type surface, so do manual once+cleanup.
-        room.off(event as any, handler as any);
-        resolve(take(...args));
-      };
-      room.on(event as any, handler as any);
-    }),
-    timeoutMs,
-    `Timed out waiting for ${event}`,
-  );
-}
 
 /**
  * Only tracks published by `identity` are the test's business. Anything else in
@@ -188,17 +62,6 @@ function expectTimestampFromCall(timestamp: number, calledAt: number, what: stri
     `(offset from call start: ${timestamp - calledAt}ms)`;
   expect(timestamp, detail).toBeGreaterThanOrEqual(calledAt - clockToleranceMs);
   expect(timestamp, detail).toBeLessThanOrEqual(now + clockToleranceMs);
-}
-
-function concatUint8(chunks: Uint8Array[]): Uint8Array {
-  const len = chunks.reduce((acc, c) => acc + c.byteLength, 0);
-  const out = new Uint8Array(len);
-  let offset = 0;
-  for (const c of chunks) {
-    out.set(c, offset);
-    offset += c.byteLength;
-  }
-  return out;
 }
 
 function channelSamples(frame: AudioFrame, channelIndex: number): Int16Array {

--- a/packages/livekit-rtc/src/tests/e2e_common.ts
+++ b/packages/livekit-rtc/src/tests/e2e_common.ts
@@ -1,0 +1,149 @@
+// SPDX-FileCopyrightText: 2026 LiveKit, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+import { AccessToken } from 'livekit-server-sdk';
+import { randomUUID } from 'node:crypto';
+import { setTimeout as delay } from 'node:timers/promises';
+import { describe } from 'vitest';
+import { Room, type RoomEvent } from '../index.js';
+
+export const hasE2EEnv =
+  !!process.env.LIVEKIT_URL && !!process.env.LIVEKIT_API_KEY && !!process.env.LIVEKIT_API_SECRET;
+// Explicitly typed so declaration emit doesn't reference vitest's
+// non-exported internal suite types (TS4023).
+export const describeE2E: typeof describe = hasE2EEnv
+  ? describe
+  : (describe.skip as typeof describe);
+export const testTimeoutMs = 10_000;
+
+export type TestEnv = {
+  url: string;
+  apiKey: string;
+  apiSecret: string;
+};
+
+function normalizeLiveKitUrl(url: string): string {
+  if (url.startsWith('http://')) return `ws://${url.slice('http://'.length)}`;
+  if (url.startsWith('https://')) return `wss://${url.slice('https://'.length)}`;
+  return url;
+}
+
+export function getTestEnv(): TestEnv {
+  if (!hasE2EEnv) {
+    throw new Error(
+      'Missing required env vars for e2e: LIVEKIT_URL, LIVEKIT_API_KEY, LIVEKIT_API_SECRET',
+    );
+  }
+  return {
+    url: normalizeLiveKitUrl(process.env.LIVEKIT_URL!),
+    apiKey: process.env.LIVEKIT_API_KEY!,
+    apiSecret: process.env.LIVEKIT_API_SECRET!,
+  };
+}
+
+export async function withTimeout<T>(
+  promise: Promise<T>,
+  timeoutMs: number,
+  message: string,
+): Promise<T> {
+  return await Promise.race([
+    promise,
+    (async () => {
+      await delay(timeoutMs);
+      throw new Error(message);
+    })(),
+  ]);
+}
+
+export async function waitFor(
+  condition: () => boolean,
+  opts: { timeoutMs: number; intervalMs?: number; debugName?: string },
+): Promise<void> {
+  const intervalMs = opts.intervalMs ?? 50;
+  const deadline = Date.now() + opts.timeoutMs;
+  while (Date.now() < deadline) {
+    if (condition()) return;
+    await delay(intervalMs);
+  }
+  throw new Error(`Timed out waiting for condition${opts.debugName ? ` (${opts.debugName})` : ''}`);
+}
+
+export async function createJoinToken(params: {
+  env: TestEnv;
+  roomName: string;
+  identity: string;
+  name: string;
+}): Promise<string> {
+  const token = new AccessToken(params.env.apiKey, params.env.apiSecret, {
+    identity: params.identity,
+    name: params.name,
+    ttl: '30m',
+  });
+  token.addGrant({
+    room: params.roomName,
+    roomJoin: true,
+    roomCreate: true,
+    canPublish: true,
+    canSubscribe: true,
+  });
+  return await token.toJwt();
+}
+
+export async function connectTestRooms(
+  count: number,
+): Promise<{ roomName: string; rooms: Room[] }> {
+  const env = getTestEnv();
+  const roomName = `test_room_${randomUUID()}`;
+  const rooms = await Promise.all(
+    Array.from({ length: count }, async (_, i) => {
+      const token = await createJoinToken({
+        env,
+        roomName,
+        identity: `p${i}`,
+        name: `Participant ${i}`,
+      });
+      const room = new Room();
+      await room.connect(env.url, token, { autoSubscribe: true, dynacast: false });
+      return room;
+    }),
+  );
+
+  const start = Date.now();
+  await waitFor(() => rooms.every((r) => r.remoteParticipants.size === count - 1), {
+    timeoutMs: 5000,
+    debugName: `participant visibility (${Date.now() - start}ms)`,
+  });
+
+  return { roomName, rooms };
+}
+
+export function waitForRoomEvent<R>(
+  room: Room,
+  event: RoomEvent,
+  timeoutMs: number,
+  take: (...args: any[]) => R,
+): Promise<R> {
+  return withTimeout(
+    new Promise<R>((resolve) => {
+      const handler = (...args: any[]) => {
+        // typed-emitter doesn't expose `.once` in the type surface, so do manual once+cleanup.
+        room.off(event as any, handler as any);
+        resolve(take(...args));
+      };
+      room.on(event as any, handler as any);
+    }),
+    timeoutMs,
+    `Timed out waiting for ${event}`,
+  );
+}
+
+export function concatUint8(chunks: Uint8Array[]): Uint8Array {
+  const len = chunks.reduce((acc, c) => acc + c.byteLength, 0);
+  const out = new Uint8Array(len);
+  let offset = 0;
+  for (const c of chunks) {
+    out.set(c, offset);
+    offset += c.byteLength;
+  }
+  return out;
+}

--- a/packages/livekit-rtc/src/tests/e2e_common.ts
+++ b/packages/livekit-rtc/src/tests/e2e_common.ts
@@ -5,7 +5,7 @@ import { AccessToken } from 'livekit-server-sdk';
 import { randomUUID } from 'node:crypto';
 import { setTimeout as delay } from 'node:timers/promises';
 import { describe } from 'vitest';
-import { Room, type RoomDataStreamOptions, type RoomEvent } from '../index.js';
+import { Room, type RoomEvent, type RoomOptions } from '../index.js';
 
 export const hasE2EEnv =
   !!process.env.LIVEKIT_URL && !!process.env.LIVEKIT_API_KEY && !!process.env.LIVEKIT_API_SECRET;
@@ -91,8 +91,11 @@ export async function createJoinToken(params: {
 
 export async function connectTestRooms(
   count: number,
-  /** Extra room options applied to every room, e.g. data stream limits. */
-  options?: { dataStream?: RoomDataStreamOptions },
+  /**
+   * Extra room options applied to every room, e.g. data stream limits or
+   * `encryption` to bring up the whole set with a shared e2ee key.
+   */
+  options?: Partial<RoomOptions>,
 ): Promise<{ roomName: string; rooms: Room[] }> {
   const env = getTestEnv();
   const roomName = `test_room_${randomUUID()}`;
@@ -128,10 +131,15 @@ export function waitForRoomEvent<R>(
   event: RoomEvent,
   timeoutMs: number,
   take: (...args: any[]) => R,
+  /** Ignore emissions that don't match, e.g. events for another participant. */
+  match?: (...args: unknown[]) => boolean,
 ): Promise<R> {
   return withTimeout(
     new Promise<R>((resolve) => {
       const handler = (...args: any[]) => {
+        if (match && !match(...args)) {
+          return;
+        }
         // typed-emitter doesn't expose `.once` in the type surface, so do manual once+cleanup.
         room.off(event as any, handler as any);
         resolve(take(...args));

--- a/packages/livekit-rtc/src/tests/e2e_common.ts
+++ b/packages/livekit-rtc/src/tests/e2e_common.ts
@@ -5,7 +5,7 @@ import { AccessToken } from 'livekit-server-sdk';
 import { randomUUID } from 'node:crypto';
 import { setTimeout as delay } from 'node:timers/promises';
 import { describe } from 'vitest';
-import { Room, type RoomEvent } from '../index.js';
+import { Room, type RoomDataStreamOptions, type RoomEvent } from '../index.js';
 
 export const hasE2EEnv =
   !!process.env.LIVEKIT_URL && !!process.env.LIVEKIT_API_KEY && !!process.env.LIVEKIT_API_SECRET;
@@ -91,6 +91,8 @@ export async function createJoinToken(params: {
 
 export async function connectTestRooms(
   count: number,
+  /** Extra room options applied to every room, e.g. data stream limits. */
+  options?: { dataStream?: RoomDataStreamOptions },
 ): Promise<{ roomName: string; rooms: Room[] }> {
   const env = getTestEnv();
   const roomName = `test_room_${randomUUID()}`;
@@ -103,7 +105,11 @@ export async function connectTestRooms(
         name: `Participant ${i}`,
       });
       const room = new Room();
-      await room.connect(env.url, token, { autoSubscribe: true, dynacast: false });
+      await room.connect(env.url, token, {
+        autoSubscribe: true,
+        dynacast: false,
+        ...options,
+      });
       return room;
     }),
   );

--- a/packages/livekit-rtc/src/tests/e2e_data_streams.test.ts
+++ b/packages/livekit-rtc/src/tests/e2e_data_streams.test.ts
@@ -1,0 +1,335 @@
+// SPDX-FileCopyrightText: 2026 LiveKit, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// End-to-end tests for data streams (text/byte streams over the FFI-backed
+// rust implementation). Ported from rust-sdks `livekit/tests/data_stream_test.rs`
+// where the node API surface allows; see comments on individual tests for
+// intentional deviations.
+import { afterAll, expect, it as itRaw } from 'vitest';
+import { dispose } from '../index.js';
+import {
+  concatUint8,
+  connectTestRooms,
+  describeE2E,
+  testTimeoutMs,
+  withTimeout,
+} from './e2e_common.js';
+
+// use concurrent testing if available on the runner (currently not supported by bun's api)
+const it = typeof itRaw.concurrent === 'function' ? itRaw.concurrent : itRaw;
+
+/** Deterministic pseudo-random lowercase text (mulberry32 PRNG).
+ *
+ * Counterpart of rust's `pseudo_random_text`: random lowercase carries
+ * ~4.7 bits of entropy per 8-bit byte, so deflate compresses it well under
+ * its raw size — exercising the chunked-compressed wire path. */
+function pseudoRandomText(length: number, seed = 0x5eed): string {
+  let a = seed >>> 0;
+  const next = () => {
+    a = (a + 0x6d2b79f5) >>> 0;
+    let t = a;
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+  const chars = new Array<string>(length);
+  for (let i = 0; i < length; i++) {
+    chars[i] = String.fromCharCode(97 + Math.floor(next() * 26));
+  }
+  return chars.join('');
+}
+
+/** Deterministic pseudo-random bytes (mulberry32 PRNG).
+ *
+ * Uniform random bytes are genuinely incompressible: deflate cannot shrink
+ * them, so the send path must fall back to an uncompressed wire format.
+ * Seeded for a deterministic, reproducible test. */
+function pseudoRandomBytes(length: number, seed = 0xc0ffee): Uint8Array {
+  let a = seed >>> 0;
+  const out = new Uint8Array(length);
+  for (let i = 0; i < length; i++) {
+    a = (a + 0x6d2b79f5) >>> 0;
+    let t = a;
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    out[i] = (t ^ (t >>> 14)) & 0xff;
+  }
+  return out;
+}
+
+describeE2E('livekit-rtc data streams e2e', () => {
+  afterAll(async () => {
+    await dispose();
+  });
+
+  // Port of rust `test_send_text`. The `is_compressed` / `is_inline` info
+  // assertions are not portable: the FFI stream-info protos don't expose them.
+  it(
+    'sends and receives a small text stream',
+    async () => {
+      const { rooms } = await connectTestRooms(2);
+      const [receivingRoom, sendingRoom] = rooms;
+      const senderIdentity = sendingRoom!.localParticipant!.identity;
+
+      const topic = 'some-topic';
+      const textToSend = 'some-text';
+
+      const receivedText = withTimeout(
+        new Promise<string>((resolve) => {
+          receivingRoom!.registerTextStreamHandler(topic, async (reader, sender) => {
+            expect(sender.identity).toBe(senderIdentity);
+            resolve(await reader.readAll());
+          });
+        }),
+        testTimeoutMs,
+        'Timed out waiting for text stream',
+      );
+
+      const textInfo = await sendingRoom!.localParticipant!.sendText(textToSend, { topic });
+      expect(textInfo.streamId).toBeTruthy();
+      expect(Math.abs(textInfo.timestamp - Date.now())).toBeLessThanOrEqual(1_000);
+      expect(textInfo.totalSize).toBe(textToSend.length);
+      expect(textInfo.mimeType).toBe('text/plain');
+      expect(textInfo.topic).toBe(topic);
+
+      expect(await receivedText).toBe(textToSend);
+
+      await Promise.all(rooms.map((r) => r.disconnect()));
+    },
+    testTimeoutMs,
+  );
+
+  // Port of rust `test_send_bytes`. Node has no `sendBytes` (in-memory one-shot)
+  // wrapper yet, so this uses the incremental `streamBytes` writer — which by
+  // design is never inlined or compressed on the wire.
+  it(
+    'sends and receives a small byte stream',
+    async () => {
+      const { rooms } = await connectTestRooms(2);
+      const [receivingRoom, sendingRoom] = rooms;
+      const senderIdentity = sendingRoom!.localParticipant!.identity;
+
+      const topic = 'some-topic';
+      const bytesToSend = new Uint8Array(16).fill(0xfa);
+
+      const receivedBytes = withTimeout(
+        new Promise<Uint8Array>((resolve) => {
+          receivingRoom!.registerByteStreamHandler(topic, async (reader, sender) => {
+            expect(sender.identity).toBe(senderIdentity);
+            const chunks = await reader.readAll();
+            resolve(concatUint8(chunks));
+          });
+        }),
+        testTimeoutMs,
+        'Timed out waiting for byte stream',
+      );
+
+      const writer = await sendingRoom!.localParticipant!.streamBytes({
+        topic,
+        totalSize: bytesToSend.byteLength,
+      });
+      await writer.write(bytesToSend);
+      await writer.close();
+
+      const byteInfo = writer.info;
+      expect(byteInfo.streamId).toBeTruthy();
+      expect(Math.abs(byteInfo.timestamp - Date.now())).toBeLessThanOrEqual(1_000);
+      expect(byteInfo.mimeType).toBe('application/octet-stream');
+      expect(byteInfo.topic).toBe(topic);
+
+      expect(await receivedBytes).toEqual(bytesToSend);
+
+      await Promise.all(rooms.map((r) => r.disconnect()));
+    },
+    testTimeoutMs,
+  );
+
+  // Port of rust `test_send_large_compressible_text`: ~50 KB of deterministic
+  // pseudo-random lowercase is too big to inline and compresses well under its
+  // raw size, so the sender emits chunked deflate-raw and the receiver
+  // decompresses — validating the v2 compression path on the real wire.
+  it(
+    'round-trips a large compressible text (chunked + compressed wire path)',
+    async () => {
+      const { rooms } = await connectTestRooms(2);
+      const [receivingRoom, sendingRoom] = rooms;
+
+      const topic = 'large-compressible-text';
+      const text = pseudoRandomText(50_000);
+
+      const receivedText = withTimeout(
+        new Promise<string>((resolve) => {
+          receivingRoom!.registerTextStreamHandler(topic, async (reader) => {
+            resolve(await reader.readAll());
+          });
+        }),
+        testTimeoutMs,
+        'Timed out waiting for large text stream',
+      );
+
+      const info = await sendingRoom!.localParticipant!.sendText(text, { topic });
+      expect(info.totalSize).toBe(text.length);
+
+      expect(await receivedText).toBe(text);
+
+      await Promise.all(rooms.map((r) => r.disconnect()));
+    },
+    testTimeoutMs,
+  );
+
+  // Port of rust `test_send_large_incompressible_random_bytes`, adapted to the
+  // incremental `streamBytes` writer (no `sendBytes` wrapper in node yet):
+  // uniform random bytes exercise the chunked, uncompressed wire path with a
+  // payload spanning many chunks.
+  it(
+    'round-trips large incompressible random bytes',
+    async () => {
+      const { rooms } = await connectTestRooms(2);
+      const [receivingRoom, sendingRoom] = rooms;
+
+      const topic = 'large-random-bytes';
+      const payload = pseudoRandomBytes(1_800_000);
+
+      const receivedBytes = withTimeout(
+        new Promise<Uint8Array>((resolve) => {
+          receivingRoom!.registerByteStreamHandler(topic, async (reader) => {
+            resolve(concatUint8(await reader.readAll()));
+          });
+        }),
+        testTimeoutMs * 2,
+        'Timed out waiting for large byte stream',
+      );
+
+      const writer = await sendingRoom!.localParticipant!.streamBytes({
+        topic,
+        totalSize: payload.byteLength,
+      });
+      const writeChunkSize = 64 * 1024;
+      for (let offset = 0; offset < payload.byteLength; offset += writeChunkSize) {
+        await writer.write(payload.subarray(offset, offset + writeChunkSize));
+      }
+      await writer.close();
+
+      const received = await receivedBytes;
+      expect(received.byteLength).toBe(payload.byteLength);
+      expect(received).toEqual(payload);
+
+      await Promise.all(rooms.map((r) => r.disconnect()));
+    },
+    testTimeoutMs * 3,
+  );
+
+  // Port of rust `test_send_large_bytes`: a 50 KB patterned (compressible)
+  // payload via the byte-stream path.
+  it(
+    'round-trips large patterned bytes',
+    async () => {
+      const { rooms } = await connectTestRooms(2);
+      const [receivingRoom, sendingRoom] = rooms;
+
+      const topic = 'large-patterned-bytes';
+      const payload = new Uint8Array(50_000);
+      for (let i = 0; i < payload.length; i++) payload[i] = i % 251;
+
+      const receivedBytes = withTimeout(
+        new Promise<Uint8Array>((resolve) => {
+          receivingRoom!.registerByteStreamHandler(topic, async (reader) => {
+            resolve(concatUint8(await reader.readAll()));
+          });
+        }),
+        testTimeoutMs,
+        'Timed out waiting for patterned byte stream',
+      );
+
+      const writer = await sendingRoom!.localParticipant!.streamBytes({
+        topic,
+        totalSize: payload.byteLength,
+      });
+      await writer.write(payload);
+      await writer.close();
+
+      expect(await receivedBytes).toEqual(payload);
+
+      await Promise.all(rooms.map((r) => r.disconnect()));
+    },
+    testTimeoutMs,
+  );
+
+  // Incremental writer path for text (multi-write, unicode content): ensures
+  // UTF-8-aware chunking on the sender doesn't split multi-byte characters.
+  it(
+    'round-trips an incremental text stream with multi-byte characters',
+    async () => {
+      const { rooms } = await connectTestRooms(2);
+      const [receivingRoom, sendingRoom] = rooms;
+
+      const topic = 'incremental-unicode-text';
+      const pieces = ['héllo wörld — ', '日本語のテキスト、', '🌍🚀 emoji tail'];
+      const expected = pieces.join('');
+
+      const receivedText = withTimeout(
+        new Promise<string>((resolve) => {
+          receivingRoom!.registerTextStreamHandler(topic, async (reader) => {
+            resolve(await reader.readAll());
+          });
+        }),
+        testTimeoutMs,
+        'Timed out waiting for incremental text stream',
+      );
+
+      const writer = await sendingRoom!.localParticipant!.streamText({ topic });
+      for (const piece of pieces) {
+        await writer.write(piece);
+      }
+      await writer.close();
+
+      expect(await receivedText).toBe(expected);
+
+      await Promise.all(rooms.map((r) => r.disconnect()));
+    },
+    testTimeoutMs,
+  );
+
+  // Moved from e2e.test.ts (kept alongside the other data-stream coverage).
+  it(
+    'cleans up stream controllers when disconnecting during an active stream',
+    async () => {
+      const { rooms } = await connectTestRooms(2);
+      const [receivingRoom, sendingRoom] = rooms;
+      const topic = 'cleanup-stream-topic';
+
+      // Register a handler on the receiving side that will intentionally
+      // NOT fully consume the stream — simulating an abandoned transfer.
+      let readerReceived = false;
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      receivingRoom!.registerTextStreamHandler(topic, async (_reader, _sender) => {
+        readerReceived = true;
+        // Deliberately do not call reader.readAll() so the stream stays open
+      });
+
+      // Start sending a text stream but don't close it
+      const writer = await sendingRoom!.localParticipant!.streamText({ topic });
+      await writer.write('partial data');
+
+      // Wait for the receiving side to get the stream header
+      const deadline = Date.now() + 5000;
+      while (!readerReceived && Date.now() < deadline) {
+        await new Promise((r) => setTimeout(r, 50));
+      }
+      expect(readerReceived).toBe(true);
+
+      // Disconnect the receiving room while the stream is still open.
+      // This should close the stream controller without throwing.
+      await receivingRoom!.disconnect();
+
+      // Also close the writer and disconnect the sender
+      await writer.close();
+      await sendingRoom!.disconnect();
+
+      // If we got here without hanging or throwing, the stream controller
+      // was properly cleaned up on disconnect.
+    },
+    testTimeoutMs,
+  );
+});

--- a/packages/livekit-rtc/src/tests/e2e_data_streams.test.ts
+++ b/packages/livekit-rtc/src/tests/e2e_data_streams.test.ts
@@ -74,7 +74,6 @@ describeE2E('livekit-rtc data streams e2e', () => {
 
       const textInfo = await sendingRoom!.localParticipant!.sendText(textToSend, { topic });
       expect(textInfo.streamId).toBeTruthy();
-      expect(Math.abs(textInfo.timestamp - Date.now())).toBeLessThanOrEqual(1_000);
       expect(textInfo.totalSize).toBe(textToSend.length);
       expect(textInfo.mimeType).toBe('text/plain');
       expect(textInfo.topic).toBe(topic);
@@ -120,7 +119,6 @@ describeE2E('livekit-rtc data streams e2e', () => {
 
       const byteInfo = writer.info;
       expect(byteInfo.streamId).toBeTruthy();
-      expect(Math.abs(byteInfo.timestamp - Date.now())).toBeLessThanOrEqual(1_000);
       expect(byteInfo.mimeType).toBe('application/octet-stream');
       expect(byteInfo.topic).toBe(topic);
 

--- a/packages/livekit-rtc/src/tests/e2e_data_streams.test.ts
+++ b/packages/livekit-rtc/src/tests/e2e_data_streams.test.ts
@@ -19,41 +19,27 @@ import {
 // use concurrent testing if available on the runner (currently not supported by bun's api)
 const it = typeof itRaw.concurrent === 'function' ? itRaw.concurrent : itRaw;
 
-/** Deterministic pseudo-random lowercase text (mulberry32 PRNG).
+/** Pseudo-random lowercase text.
  *
  * Counterpart of rust's `pseudo_random_text`: random lowercase carries
  * ~4.7 bits of entropy per 8-bit byte, so deflate compresses it well under
  * its raw size — exercising the chunked-compressed wire path. */
-function pseudoRandomText(length: number, seed = 0x5eed): string {
-  let a = seed >>> 0;
-  const next = () => {
-    a = (a + 0x6d2b79f5) >>> 0;
-    let t = a;
-    t = Math.imul(t ^ (t >>> 15), t | 1);
-    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
-    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
-  };
+function pseudoRandomText(length: number): string {
   const chars = new Array<string>(length);
   for (let i = 0; i < length; i++) {
-    chars[i] = String.fromCharCode(97 + Math.floor(next() * 26));
+    chars[i] = String.fromCharCode(97 + Math.floor(Math.random() * 26));
   }
   return chars.join('');
 }
 
-/** Deterministic pseudo-random bytes (mulberry32 PRNG).
+/** Pseudo-random bytes.
  *
  * Uniform random bytes are genuinely incompressible: deflate cannot shrink
- * them, so the send path must fall back to an uncompressed wire format.
- * Seeded for a deterministic, reproducible test. */
-function pseudoRandomBytes(length: number, seed = 0xc0ffee): Uint8Array {
-  let a = seed >>> 0;
+ * them, so the send path must fall back to an uncompressed wire format. */
+function pseudoRandomBytes(length: number): Uint8Array {
   const out = new Uint8Array(length);
   for (let i = 0; i < length; i++) {
-    a = (a + 0x6d2b79f5) >>> 0;
-    let t = a;
-    t = Math.imul(t ^ (t >>> 15), t | 1);
-    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
-    out[i] = (t ^ (t >>> 14)) & 0xff;
+    out[i] = Math.floor(Math.random() * 256);
   }
   return out;
 }

--- a/packages/livekit-rtc/src/tests/e2e_data_streams.test.ts
+++ b/packages/livekit-rtc/src/tests/e2e_data_streams.test.ts
@@ -601,4 +601,39 @@ describeE2E('livekit-rtc data streams e2e', () => {
     },
     testTimeoutMs,
   );
+
+  it(
+    'releases the FFI subscription when a progress callback throws',
+    async () => {
+      const { rooms } = await connectTestRooms(2);
+      const [receivingRoom, sendingRoom] = rooms;
+      const topic = 'throwing-progress-topic';
+
+      const handed = withTimeout(
+        new Promise<TextStreamReader>((resolve) => {
+          receivingRoom!.registerTextStreamHandler(topic, resolve);
+        }),
+        testTimeoutMs,
+        'Timed out waiting for the stream handler to be called',
+      );
+
+      // Left open so the stream is still live when the callback throws: the
+      // reader has to cancel it, rather than assume a terminal stream event
+      // already dropped the FFI subscription.
+      const writer = await sendingRoom!.localParticipant!.streamText({ topic });
+      await writer.write('first chunk');
+
+      const reader = await handed;
+      reader.onProgress = () => {
+        throw new Error('progress callback exploded');
+      };
+
+      await expect(reader.readAll()).rejects.toThrow(/progress callback exploded/);
+      expect(subscribedReaderCount(receivingRoom!)).toBe(0);
+
+      await writer.close();
+      await Promise.all(rooms.map((r) => r.disconnect()));
+    },
+    testTimeoutMs,
+  );
 });

--- a/packages/livekit-rtc/src/tests/e2e_data_streams.test.ts
+++ b/packages/livekit-rtc/src/tests/e2e_data_streams.test.ts
@@ -7,17 +7,38 @@
 // where the node API surface allows; see comments on individual tests for
 // intentional deviations.
 import { afterAll, expect, it as itRaw } from 'vitest';
+import type { Room, TextStreamReader } from '../index.js';
 import { dispose } from '../index.js';
 import {
   concatUint8,
   connectTestRooms,
   describeE2E,
   testTimeoutMs,
+  waitFor,
   withTimeout,
 } from './e2e_common.js';
 
 // use concurrent testing if available on the runner (currently not supported by bun's api)
 const it = typeof itRaw.concurrent === 'function' ? itRaw.concurrent : itRaw;
+
+/** How many of this room's incoming stream readers are still subscribed to FFI
+ * events.
+ *
+ * Reads the room's private reader registry rather than counting FfiClient
+ * listeners: an entry is added when a reader subscribes and removed when it
+ * unsubscribes, so the count is specific to this room and unaffected by the
+ * other tests running concurrently. */
+function subscribedReaderCount(room: Room): number {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return ((room as any).streamReaders as Map<unknown, unknown>).size;
+}
+
+async function waitForNoSubscribedReaders(room: Room): Promise<void> {
+  await waitFor(() => subscribedReaderCount(room) === 0, {
+    timeoutMs: 5000,
+    debugName: 'stream reader to unsubscribe from FFI events',
+  });
+}
 
 /** Pseudo-random lowercase text.
  *
@@ -313,6 +334,201 @@ describeE2E('livekit-rtc data streams e2e', () => {
 
       // If we got here without hanging or throwing, the stream controller
       // was properly cleaned up on disconnect.
+    },
+    testTimeoutMs,
+  );
+
+  it(
+    'releases the FFI subscription when a reader is abandoned mid-iteration',
+    async () => {
+      const { rooms } = await connectTestRooms(2);
+      const [receivingRoom, sendingRoom] = rooms;
+      const topic = 'abandon-topic';
+
+      // Unlike python, walking out of the loop is enough: `break` runs the
+      // async iterator's return(), which closes the reader for us.
+      const abandoned = withTimeout(
+        new Promise<{ reader: TextStreamReader; firstChunk: string }>((resolve) => {
+          receivingRoom!.registerTextStreamHandler(topic, async (reader) => {
+            for await (const chunk of reader) {
+              resolve({ reader, firstChunk: chunk });
+              break; // walk away without draining to end-of-stream
+            }
+          });
+        }),
+        testTimeoutMs,
+        'Timed out waiting for the reader to be abandoned',
+      );
+
+      await sendingRoom!.localParticipant!.sendText(pseudoRandomText(50_000), { topic });
+      const { reader, firstChunk } = await abandoned;
+      expect(firstChunk.length).toBeGreaterThan(0);
+
+      await waitForNoSubscribedReaders(receivingRoom!);
+
+      // Closing an already-closed reader is a no-op.
+      await reader.close();
+      expect(subscribedReaderCount(receivingRoom!)).toBe(0);
+
+      await Promise.all(rooms.map((r) => r.disconnect()));
+    },
+    testTimeoutMs,
+  );
+
+  it(
+    'releases the FFI subscription when a reader is never read',
+    async () => {
+      const { rooms } = await connectTestRooms(2);
+      const [receivingRoom, sendingRoom] = rooms;
+      const topic = 'noread-topic';
+
+      const handed = withTimeout(
+        new Promise<TextStreamReader>((resolve) => {
+          receivingRoom!.registerTextStreamHandler(topic, async (reader) => {
+            resolve(reader); // never read
+          });
+        }),
+        testTimeoutMs,
+        'Timed out waiting for the stream handler to be called',
+      );
+
+      const writer = await sendingRoom!.localParticipant!.streamText({ topic });
+      await writer.write('some data');
+
+      const reader = await handed;
+      expect(subscribedReaderCount(receivingRoom!)).toBe(1);
+
+      await reader.close();
+      expect(subscribedReaderCount(receivingRoom!)).toBe(0);
+      await reader.close(); // idempotent
+
+      await writer.close();
+      await Promise.all(rooms.map((r) => r.disconnect()));
+    },
+    testTimeoutMs,
+  );
+
+  it(
+    'ends an in-flight read when the reader is closed mid-stream',
+    async () => {
+      const { rooms } = await connectTestRooms(2);
+      const [receivingRoom, sendingRoom] = rooms;
+      const topic = 'close-during-read-topic';
+
+      const reading = withTimeout(
+        new Promise<{ reader: TextStreamReader; read: Promise<string> }>((resolve) => {
+          receivingRoom!.registerTextStreamHandler(topic, async (reader) => {
+            // readAll() blocks on a stream that is deliberately left open.
+            resolve({ reader, read: reader.readAll() });
+          });
+        }),
+        testTimeoutMs,
+        'Timed out waiting for the stream handler to be called',
+      );
+
+      const writer = await sendingRoom!.localParticipant!.streamText({ topic });
+      await writer.write('first chunk');
+
+      const { reader, read } = await reading;
+      // Let the read consume the first chunk and block waiting for more.
+      await waitFor(() => subscribedReaderCount(receivingRoom!) === 1, {
+        timeoutMs: 5000,
+        debugName: 'reader to subscribe',
+      });
+
+      await reader.close();
+
+      // The blocked read ends rather than hanging, with what it had so far.
+      const text = await withTimeout(read, testTimeoutMs, 'Timed out on the in-flight read');
+      expect('first chunk'.startsWith(text)).toBe(true);
+      expect(subscribedReaderCount(receivingRoom!)).toBe(0);
+
+      await writer.close();
+      await Promise.all(rooms.map((r) => r.disconnect()));
+    },
+    testTimeoutMs,
+  );
+
+  it(
+    'drops the subscription of an unread reader when the room disconnects',
+    async () => {
+      const { rooms } = await connectTestRooms(2);
+      const [receivingRoom, sendingRoom] = rooms;
+      const topic = 'disconnect-unread-topic';
+
+      const handed = withTimeout(
+        new Promise<TextStreamReader>((resolve) => {
+          receivingRoom!.registerTextStreamHandler(topic, async (reader) => {
+            resolve(reader); // never read
+          });
+        }),
+        testTimeoutMs,
+        'Timed out waiting for the stream handler to be called',
+      );
+
+      const writer = await sendingRoom!.localParticipant!.streamText({ topic });
+      await writer.write('buffered ');
+      await writer.write('data');
+
+      const reader = await handed;
+      expect(subscribedReaderCount(receivingRoom!)).toBe(1);
+
+      await receivingRoom!.disconnect();
+      expect(subscribedReaderCount(receivingRoom!)).toBe(0);
+
+      // The read settles rather than hanging. Which way it settles is a race
+      // the SDK doesn't control: the native side emits a clean end-of-stream
+      // when the room drops the stream (livekit-ffi `read_incremental` sends
+      // `eos { error: None }` once the channel closes), so either that lands
+      // first and the read returns the chunks buffered so far, or disconnect
+      // cleanup errors the stream first and the read reports that. Python is
+      // deterministic here because it injects a synthetic error end-of-stream.
+      const readResult = await withTimeout(
+        reader.readAll().then(
+          (text) => ({ text }),
+          (err: unknown) => ({ err }),
+        ),
+        testTimeoutMs,
+        'Timed out reading a reader whose room disconnected',
+      );
+      if ('err' in readResult) {
+        expect(String(readResult.err)).toMatch(/Disconnected while receiving/);
+      } else {
+        expect('buffered data'.startsWith(readResult.text)).toBe(true);
+      }
+
+      await writer.close();
+      await sendingRoom!.disconnect();
+    },
+    testTimeoutMs,
+  );
+
+  it(
+    'needs no close once a reader has been read to completion',
+    async () => {
+      const { rooms } = await connectTestRooms(2);
+      const [receivingRoom, sendingRoom] = rooms;
+      const topic = 'drain-topic';
+
+      const drained = withTimeout(
+        new Promise<{ reader: TextStreamReader; text: string }>((resolve) => {
+          receivingRoom!.registerTextStreamHandler(topic, async (reader) => {
+            resolve({ reader, text: await reader.readAll() });
+          });
+        }),
+        testTimeoutMs,
+        'Timed out waiting for the text stream',
+      );
+
+      await sendingRoom!.localParticipant!.sendText('hello', { topic });
+      const { reader, text } = await drained;
+      expect(text).toBe('hello');
+
+      await waitForNoSubscribedReaders(receivingRoom!);
+      await reader.close(); // no-op
+      expect(subscribedReaderCount(receivingRoom!)).toBe(0);
+
+      await Promise.all(rooms.map((r) => r.disconnect()));
     },
     testTimeoutMs,
   );

--- a/packages/livekit-rtc/src/tests/e2e_data_streams.test.ts
+++ b/packages/livekit-rtc/src/tests/e2e_data_streams.test.ts
@@ -532,4 +532,73 @@ describeE2E('livekit-rtc data streams e2e', () => {
     },
     testTimeoutMs,
   );
+
+  it(
+    'reads a closed reader as an empty stream',
+    async () => {
+      const { rooms } = await connectTestRooms(2);
+      const [receivingRoom, sendingRoom] = rooms;
+      const topic = 'read-after-close-topic';
+
+      const handed = withTimeout(
+        new Promise<TextStreamReader>((resolve) => {
+          receivingRoom!.registerTextStreamHandler(topic, async (reader) => {
+            resolve(reader); // never read
+          });
+        }),
+        testTimeoutMs,
+        'Timed out waiting for the stream handler to be called',
+      );
+
+      const writer = await sendingRoom!.localParticipant!.streamText({ topic });
+      await writer.write('never consumed');
+
+      const reader = await handed;
+      await reader.close();
+
+      const text = await withTimeout(
+        reader.readAll(),
+        testTimeoutMs,
+        'Timed out reading a closed reader',
+      );
+      expect(text).toBe('');
+
+      await writer.close();
+      await Promise.all(rooms.map((r) => r.disconnect()));
+    },
+    testTimeoutMs,
+  );
+
+  // `dataStream.maxPayloadByteLength` caps what a receiver will accept (5gb by
+  // default). The native side emits the stream to the handler first and then
+  // fails it, so the error surfaces on the read rather than as a missing stream.
+  it(
+    'fails the read when an incoming stream exceeds maxPayloadByteLength',
+    async () => {
+      const maxPayloadByteLength = 1000;
+      const { rooms } = await connectTestRooms(2, { dataStream: { maxPayloadByteLength } });
+      const [receivingRoom, sendingRoom] = rooms;
+      const topic = 'oversized-topic';
+
+      const handed = withTimeout(
+        new Promise<TextStreamReader>((resolve) => {
+          receivingRoom!.registerTextStreamHandler(topic, resolve);
+        }),
+        testTimeoutMs,
+        'Timed out waiting for the oversized stream to be handed to the handler',
+      );
+
+      // sendText declares the payload's total length up front, so the receiver
+      // rejects the stream on the header without reading any of it.
+      await sendingRoom!.localParticipant!.sendText(pseudoRandomText(maxPayloadByteLength * 5), {
+        topic,
+      });
+
+      const reader = await handed;
+      await expect(reader.readAll()).rejects.toThrow(/payload exceeds maximum size/);
+
+      await Promise.all(rooms.map((r) => r.disconnect()));
+    },
+    testTimeoutMs,
+  );
 });

--- a/packages/livekit-rtc/src/utils.ts
+++ b/packages/livekit-rtc/src/utils.ts
@@ -1,6 +1,11 @@
 // SPDX-FileCopyrightText: 2024 LiveKit, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
+import type {
+  ByteStreamInfo as ProtoByteStreamInfo,
+  TextStreamInfo as ProtoTextStreamInfo,
+} from '@livekit/rtc-ffi-bindings';
+import type { ByteStreamInfo, TextStreamInfo } from './data_streams/types.js';
 
 /** convert bigints to numbers preserving undefined values */
 export function bigIntToNumber<T extends bigint | undefined>(
@@ -39,4 +44,29 @@ export function splitUtf8(s: string, n: number): Uint8Array[] {
     result.push(encoded);
   }
   return result;
+}
+
+/** @internal */
+export function textStreamInfoFromProto(info: ProtoTextStreamInfo): TextStreamInfo {
+  return {
+    streamId: info.streamId!,
+    mimeType: info.mimeType!,
+    topic: info.topic!,
+    timestamp: bigIntToNumber(info.timestamp!),
+    totalSize: info.totalLength !== undefined ? bigIntToNumber(info.totalLength) : undefined,
+    attributes: info.attributes,
+  };
+}
+
+/** @internal */
+export function byteStreamInfoFromProto(info: ProtoByteStreamInfo): ByteStreamInfo {
+  return {
+    streamId: info.streamId!,
+    name: info.name ?? 'unknown',
+    mimeType: info.mimeType!,
+    topic: info.topic!,
+    timestamp: bigIntToNumber(info.timestamp!),
+    totalSize: info.totalLength !== undefined ? bigIntToNumber(info.totalLength) : undefined,
+    attributes: info.attributes,
+  };
 }

--- a/packages/livekit-rtc/src/utils.ts
+++ b/packages/livekit-rtc/src/utils.ts
@@ -53,7 +53,7 @@ export function textStreamInfoFromProto(info: ProtoTextStreamInfo): TextStreamIn
     mimeType: info.mimeType!,
     topic: info.topic!,
     timestamp: bigIntToNumber(info.timestamp!),
-    totalSize: info.totalLength !== undefined ? bigIntToNumber(info.totalLength) : undefined,
+    totalSize: info.totalLength ? bigIntToNumber(info.totalLength) : undefined,
     attributes: info.attributes,
   };
 }


### PR DESCRIPTION
Previously, the node sdk had its own data streams implementation. My understanding is there isn't really a good reason for this, and it's more of an artifact of history - the node/python sdks had data streams added first, and the rust implementation came later on.

With [data streams v2](https://github.com/livekit/client-sdk-js/pull/1985), the rust implementation will both be quite a bit more stable and gain some new features that make it significantly more performant (single packet data streams and DEFLATE compression when it makes the payload smaller). This roughly _doubles_ data stream throughput in local testing.

So, port the node sdk to use the rust sdk data streams v2 implementation, and completely remove the typescript implementation. This is being done via the already-existing `livekit-ffi` data streams messages which the C++ and unity sdks use today. This is a substantial change which needs thorough testing.

## New behaviors worth being aware of
All of these are either data streams v2 related changes, or bug fixes.

### 1. `compress` option
When sending a data stream, there is a new `compress` option. Just like how this works on web / rust, this defaults to `true`. If set to `false`, then compression will be disabled (useful if you know the data you are sending isn't compressible / you are doing your own compression, which is not uncommon in robotics use cases). The vast majority of users should leave this set to `true`.

### 2. Max data stream size
In a [rust data streams v2 pull request review comment](https://github.com/livekit/rust-sdks/pull/1192#discussion_r3571761970), we decided that for security reasons it made sense to introduce a maximum data stream size as a DOS protection. This limit is by default `5gb` - any data stream that is larger will now read up until that point, and if the stream keeps going, a "payload too large" error will be raised on the stream and exposed to a user on the subsequent `.read()` call.

If a user is sending a large file, they can override this by setting a new `dataStream.maxPayloadByteLength` option on the `room.connect` call:
```typescript
room.connect(url, token, { autoSubscribe: true, dynacast: false, dataStream: { maxPayloadByteLength: 1000 } });
```

### 3. Throwing data stream errors rather than exclusively logging them
The old node specific data streams implementation didn't properly surface errors to the caller which were encountered while reading the stream. As a prerequisite for exposing the error for item 2, I fixed this, but it means that now if a data stream were to fail, errors would get thrown when in the past they would get logged and dropped.


## Testing
I've tested this as best as I can locally but I'd really like some help from agents folks to really put this through the ringer and make sure I haven't inadvertently broken something.

## Todo
- [x] Merge data streams v2 and do a rust release - https://github.com/livekit/client-sdk-js/pull/1985)
- [x] Bump the rust ffi version here and get ci passing
- [x] Do another round of testing