### PR TITLE
fix(server-sdk): require exp claim when verifying access tokens

### DIFF
--- a/.changeset/require-exp-token-verify.md
+++ b/.changeset/require-exp-token-verify.md
@@ -1,0 +1,5 @@
+---
+'livekit-server-sdk': patch
+---
+
+Require the exp claim when verifying access tokens, matching livekit/protocol#1706.

--- a/packages/livekit-server-sdk/src/AccessToken.test.ts
+++ b/packages/livekit-server-sdk/src/AccessToken.test.ts
@@ -64,6 +64,19 @@ describe('identity is required for only join grants', () => {
 });
 
 describe('verify token is valid', () => {
+  it('rejects a token that omits exp', async () => {
+    const secret = new TextEncoder().encode(testSecret);
+    const token = await new jose.SignJWT({ video: { roomCreate: true } })
+      .setProtectedHeader({ alg: 'HS256' })
+      .setIssuer(testApiKey)
+      .setSubject('me')
+      .setNotBefore(new Date())
+      .sign(secret);
+
+    const v = new TokenVerifier(testApiKey, testSecret);
+    await expect(v.verify(token)).rejects.toThrow();
+  });
+
   it('can decode encoded token', async () => {
     const t = new AccessToken(testApiKey, testSecret);
     t.sha256 = 'abcdefg';

--- a/packages/livekit-server-sdk/src/AccessToken.ts
+++ b/packages/livekit-server-sdk/src/AccessToken.ts
@@ -231,6 +231,9 @@ export class TokenVerifier {
     const { payload } = await jose.jwtVerify(token, secret, {
       issuer: this.apiKey,
       clockTolerance,
+      // First-party minters always set exp. Without this, a hand-rolled token
+      // with a valid signature and no exp verifies forever (livekit/protocol#1706).
+      requiredClaims: ['exp'],
     });
     if (!payload) {
       throw Error('invalid token');


### PR DESCRIPTION
## Problem

`TokenVerifier.verify` calls `jose.jwtVerify` with issuer and clock tolerance only. Jose does not require `exp` unless `requiredClaims` or `maxTokenAge` is set, so a hand-rolled token with a valid signature and no expiry verifies forever.

First-party `AccessToken.toJwt` always sets `exp`. This is the same gap livekit/protocol#1706 closed on the Go verifier and livekit/python-sdks#779 on the Python verifier.

## Fix

Pass `requiredClaims: ['exp']`.

Threat-model: the attacker can mint or obtain an HS256 token that omits `exp`. They do not control the verifier secret or clock. Signature verification still succeeds and the credential never ages out. That is permanent access from a forgotten expiry, not host or agent authority.

## Test plan

- `pnpm exec vitest --environment node run src/AccessToken.test.ts` (9/9)
- Revert-tested: removing `requiredClaims: ['exp']` makes `rejects a token that omits exp` fail (the token is accepted)

Made with [Cursor](https://cursor.com)