### PR TITLE
node-sdks: pick up protocol passthrough field

### DIFF
--- a/.changeset/egress-passthrough-preset.md
+++ b/.changeset/egress-passthrough-preset.md
@@ -1,0 +1,5 @@
+---
+'livekit-server-sdk': minor
+---
+
+Support the `PASSTHROUGH` encoding preset on `startEgress`, for single-track `MediaSource` egress that skips transcoding

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,8 +7,8 @@ settings:
 catalogs:
   default:
     '@livekit/protocol':
-      specifier: 1.48.0
-      version: 1.48.0
+      specifier: 1.51.0
+      version: 1.51.0
 
 importers:
 
@@ -82,7 +82,7 @@ importers:
     dependencies:
       '@livekit/protocol':
         specifier: 'catalog:'
-        version: 1.48.0
+        version: 1.51.0
       dotenv:
         specifier: ^16.4.5
         version: 16.4.5
@@ -254,7 +254,7 @@ importers:
         version: 1.10.1
       '@livekit/protocol':
         specifier: 'catalog:'
-        version: 1.48.0
+        version: 1.51.0
       jose:
         specifier: ^5.1.2
         version: 5.9.6
@@ -994,8 +994,8 @@ packages:
   '@livekit/mutex@1.1.1':
     resolution: {integrity: sha512-EsshAucklmpuUAfkABPxJNhzj9v2sG7JuzFDL4ML1oJQSV14sqrpTYnsaOudMAw9yOaW53NU3QQTlUQoRs4czw==}
 
-  '@livekit/protocol@1.48.0':
-    resolution: {integrity: sha512-fYHYgltH6YavAsokl3qsHLkBdQeKCl4UORVTub5crS3t8JtKFZ0uinHDFQ+XXdNKS6Ub9gcOjV+UHcDiqnWXoQ==}
+  '@livekit/protocol@1.51.0':
+    resolution: {integrity: sha512-kEDEDaFvIcp5VlYBromdSKMJMEJKfPvXPfEaJPdEz1Qgo84gZAoLF2g58CcMlVYGsjrwE5XYgQxRS5B7KuEj3w==}
 
   '@livekit/rtc-ffi-bindings-darwin-arm64@0.12.73':
     resolution: {integrity: sha512-gIGftVyO1Jl266AZPRzoL6dxck969dmIiaut3+D1aCZRkDb/gLz98BEGRfOSU3X0LS4QBkmiaYWsjN9ot/zmwg==}
@@ -4445,7 +4445,7 @@ snapshots:
 
   '@livekit/mutex@1.1.1': {}
 
-  '@livekit/protocol@1.48.0':
+  '@livekit/protocol@1.51.0':
     dependencies:
       '@bufbuild/protobuf': 1.10.1
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -8,4 +8,4 @@ minimumReleaseAgeExclude:
   - '@livekit/*'
 
 catalog:
-  '@livekit/protocol': 1.48.0
+  '@livekit/protocol': 1.51.0


### PR DESCRIPTION
livekit-server-sdk builds and tests green against the published @livekit/protocol containing the passthrough field
