### PR TITLE
Update tests to expect new SIP 486 GRPC code mapping

### DIFF
--- a/packages/livekit-server-sdk/README.md
+++ b/packages/livekit-server-sdk/README.md
@@ -175,7 +175,7 @@ try {
   });
 } catch (e) {
   if (e instanceof SipCallError) {
-    console.log(e.message); // e.g. "SIP call failed: 486 Busy Here (resource_exhausted)"
+    console.log(e.message); // e.g. "SIP call failed: 486 Busy Here (failed_precondition)"
     if (e.sipStatusCode === 486) {
       // callee is busy
     }

--- a/packages/livekit-server-sdk/src/TwirpRPC.test.ts
+++ b/packages/livekit-server-sdk/src/TwirpRPC.test.ts
@@ -11,7 +11,7 @@ describe('SipCallError', () => {
         'Too Many Requests',
         'twirp error: sip status 486',
         429,
-        'resource_exhausted',
+        'failed_precondition',
         {
           sip_status_code: '486',
           sip_status: 'Busy Here',
@@ -30,7 +30,7 @@ describe('SipCallError', () => {
     expect(printed).toContain('SipCallError');
     expect(printed).toContain('486');
     expect(printed).toContain('Busy Here');
-    expect(printed).toContain('resource_exhausted');
+    expect(printed).toContain('failed_precondition');
     expect(printed).toContain('region=us-east'); // other metadata is surfaced
     expect(printed).not.toContain('error_details'); // opaque blob is omitted
   });

--- a/packages/livekit-server-sdk/test/api/livekitapi.test.ts
+++ b/packages/livekit-server-sdk/test/api/livekitapi.test.ts
@@ -466,7 +466,7 @@ d('LiveKitAPI', () => {
   // A failed dial surfaces the SIP response status as a SipCallError, whose
   // getters expose the SIP code/reason while the generic Twirp code is preserved.
   describe('sip call errors', () => {
-    it('surfaces a busy signal (resource_exhausted)', async () => {
+    it('surfaces a busy signal (failed_precondition)', async () => {
       const err = await withMock({ sipStatus: { code: 486, status: 'Busy Here' } }, () =>
         api.sip.createSipParticipant('ST_abc123', '+15105550100', 'test-room'),
       ).catch((e: unknown) => e);
@@ -474,7 +474,7 @@ d('LiveKitAPI', () => {
       expect(err).toBeInstanceOf(SipCallError);
       expect(err).toBeInstanceOf(ServerError);
       const sipErr = err as SipCallError;
-      expect(sipErr.code).toBe('resource_exhausted');
+      expect(sipErr.code).toBe('failed_precondition');
       expect(sipErr.sipStatusCode).toBe(486);
       expect(sipErr.sipStatus).toBe('Busy Here');
       // printable representation makes the failure clear


### PR DESCRIPTION
This fixes a test that's failing because the SIP -> GRPC code mapping was changed (see here: https://github.com/livekit/protocol/pull/1766)