### PR TITLE
docs(rtc-node): remove outdated Developer Preview notice from README

### DIFF
--- a/.changeset/clever-pandas-shave.md
+++ b/.changeset/clever-pandas-shave.md
@@ -1,0 +1,5 @@
+---
+'@livekit/rtc-node': patch
+---
+
+Remove the outdated "Developer Preview / not ready for production" notice from the README

--- a/packages/livekit-rtc/README.md
+++ b/packages/livekit-rtc/README.md
@@ -11,11 +11,6 @@ SPDX-License-Identifier: Apache-2.0
 
 Use this SDK to add realtime video, audio and data features to your Node app. By connecting to a self- or cloud-hosted <a href="https://livekit.io/">LiveKit</a> server, you can quickly build applications like interactive live streaming or video calls with just a few lines of code.
 
-
-> This SDK is currently in Developer Preview mode and not ready for production use. There will be bugs and APIs may change during this period.
->
-> We welcome and appreciate any feedback or contributions. You can create issues here or chat live with us in the #dev channel within the [LiveKit Community Slack](https://livekit.io/join-slack).
-
 ### Warning
 
 Avoid running this with hot reloads (ex. [bun's hot reload](https://bun.sh/guides/http/hot)). This is known to cause issues with WebRTC connectivity.


### PR DESCRIPTION
## Problem

The `@livekit/rtc-node` README still opens with:

> This SDK is currently in Developer Preview mode and not ready for production use. There will be bugs and APIs may change during this period.

This came up from a customer (via support) who noticed the mismatch between that label and the package's actual status. They're right — it's stale:

- The package has shipped regular releases since 2024 and is currently at **0.13.34**.
- **`@livekit/agents` v1.8.0 declares `@livekit/rtc-node: ^0.13.34` as a peer dependency**, so anyone running the Node Agents SDK is already depending on it.

Because this text renders on npmjs.com, it's the first thing evaluating customers read.

## Change

Removes the notice block. This matches [`livekit/python-sdks`](https://github.com/livekit/python-sdks), whose realtime SDK README has no equivalent banner (and never did — `git log -S "Developer Preview"` on that repo is empty); it goes straight from the description into usage.

The "we welcome feedback / #dev channel" line that lived in the same blockquote is dropped too, since the **Getting help / Contributing** section at the bottom of this README already says the same thing — again matching the Python repo's structure.

Deliberately **not** replacing it with a "production ready" claim. That reads as a support commitment and invites follow-up questions about documented scale limits, which is a product/DevRel call rather than a README change.

Includes a patch changeset so the corrected README gets republished to npm.

## Note for reviewers

Node `@livekit/rtc-node` is still `0.13.x` while Python `livekit-rtc` is at `1.1.17`. I considered keeping a short "not yet 1.0, breaking changes may land in minor versions" caveat to reflect that, but opted for consistency with the Python README. Happy to add it back if you'd rather be explicit about the 0.x contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)