### PR TITLE
failover: retry the same host when no fallback origin exists, and cover the Cloud API hosts

### DIFF
--- a/.changeset/cloud-api-failover.md
+++ b/.changeset/cloud-api-failover.md
@@ -1,0 +1,5 @@
+---
+'livekit-server-sdk': patch
+---
+
+Retry LiveKit Cloud API (`cloud-api.livekit.io`) requests on transport errors instead of failing after a single attempt.

--- a/packages/livekit-server-sdk/src/TwirpRPC.test.ts
+++ b/packages/livekit-server-sdk/src/TwirpRPC.test.ts
@@ -112,3 +112,66 @@ describe('request id', () => {
     expect(new Set(ids).size).toBe(1);
   });
 });
+
+describe('failover without a fallback origin', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  // No /settings/regions, so no fallback origin ever exists.
+  const host = 'https://cloud-api.example.com';
+
+  const okResponse = () =>
+    ({ ok: true, status: 200, json: async () => ({}) }) as unknown as Response;
+
+  const errorResponse = (status: number) =>
+    ({
+      ok: false,
+      status,
+      statusText: 'Bad Gateway',
+      headers: { get: () => null },
+      text: async () => 'bad gateway',
+    }) as unknown as Response;
+
+  const isDiscovery = (input: unknown) => `${input}`.endsWith('/settings/regions');
+
+  it('without a fallback origin, a transport error retries the same host', async () => {
+    let attempt = 0;
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation(async (input) => {
+      if (isDiscovery(input)) {
+        return errorResponse(404);
+      }
+      attempt += 1;
+      if (attempt === 1) {
+        throw new Error('read: connection reset by peer');
+      }
+      return okResponse();
+    });
+
+    const rpc = new TwirpRpc(host, 'livekit', { failoverForce: true, failoverBackoffMs: 0 });
+    await expect(rpc.request('RoomService', 'CreateRoom', {}, {})).resolves.toEqual({});
+
+    const attempts = fetchSpy.mock.calls.filter(([input]) => !isDiscovery(input));
+    expect(attempts).toHaveLength(2);
+    expect(attempts.map(([input]) => new URL(`${input}`).host)).toEqual([
+      'cloud-api.example.com',
+      'cloud-api.example.com',
+    ]);
+  });
+
+  it('without a fallback origin, a 5xx retries the same host', async () => {
+    let attempt = 0;
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation(async (input) => {
+      if (isDiscovery(input)) {
+        return errorResponse(404);
+      }
+      attempt += 1;
+      return attempt === 1 ? errorResponse(502) : okResponse();
+    });
+
+    const rpc = new TwirpRpc(host, 'livekit', { failoverForce: true, failoverBackoffMs: 0 });
+    await expect(rpc.request('RoomService', 'CreateRoom', {}, {})).resolves.toEqual({});
+
+    expect(fetchSpy.mock.calls.filter(([input]) => !isDiscovery(input))).toHaveLength(2);
+  });
+});

--- a/packages/livekit-server-sdk/src/TwirpRPC.test.ts
+++ b/packages/livekit-server-sdk/src/TwirpRPC.test.ts
@@ -159,6 +159,26 @@ describe('failover without a fallback origin', () => {
     ]);
   });
 
+  it('a Cloud API host retries without consulting region discovery', async () => {
+    let attempt = 0;
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation(async (input) => {
+      if (isDiscovery(input)) {
+        return errorResponse(404);
+      }
+      attempt += 1;
+      if (attempt === 1) {
+        throw new Error('read: connection reset by peer');
+      }
+      return okResponse();
+    });
+
+    const rpc = new TwirpRpc('https://cloud-api.livekit.io', 'livekit', { failoverBackoffMs: 0 });
+    await expect(rpc.request('RoomService', 'CreateRoom', {}, {})).resolves.toEqual({});
+
+    expect(fetchSpy.mock.calls.filter(([input]) => isDiscovery(input))).toHaveLength(0);
+    expect(fetchSpy.mock.calls.filter(([input]) => !isDiscovery(input))).toHaveLength(2);
+  });
+
   it('without a fallback origin, a 5xx retries the same host', async () => {
     let attempt = 0;
     const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation(async (input) => {

--- a/packages/livekit-server-sdk/src/TwirpRPC.ts
+++ b/packages/livekit-server-sdk/src/TwirpRPC.ts
@@ -7,6 +7,7 @@ import {
   FAILOVER_BACKOFF_BASE_MS,
   failoverAttempts,
   hostKey,
+  isCloudApi,
   pickNext,
   regionOrigins,
   sleep,
@@ -196,7 +197,8 @@ export class TwirpRpc {
       timeout,
     );
     const attempted = new Set([hostKey(origin)]);
-    let regions: string[] | undefined;
+    // A Cloud API host has a single origin; region discovery is never consulted.
+    let regions: string[] | undefined = isCloudApi(origin.hostname) ? [] : undefined;
     let current = this.host;
 
     for (let attempt = 0; attempt < maxAttempts; attempt += 1) {

--- a/packages/livekit-server-sdk/src/TwirpRPC.ts
+++ b/packages/livekit-server-sdk/src/TwirpRPC.ts
@@ -231,7 +231,8 @@ export class TwirpRpc {
         if (!regions) {
           regions = await regionOrigins(origin, headers);
         }
-        next = pickNext(regions, attempted);
+        // With no fallback origin, a retryable failure is retried against the same host.
+        next = pickNext(regions, attempted) ?? current;
       }
 
       if (!retryable || next === undefined) {

--- a/packages/livekit-server-sdk/src/failover.test.ts
+++ b/packages/livekit-server-sdk/src/failover.test.ts
@@ -19,8 +19,15 @@ describe('failoverAttempts', () => {
     expect(failoverAttempts(true, 'myproject.region.livekit.cloud')).toBe(FAILOVER_MAX_ATTEMPTS);
   });
 
+  it('fails over for the LiveKit Cloud API hosts', () => {
+    expect(failoverAttempts(true, 'cloud-api.livekit.io')).toBe(FAILOVER_MAX_ATTEMPTS);
+    expect(failoverAttempts(true, 'cloud-api.staging.livekit.io')).toBe(FAILOVER_MAX_ATTEMPTS);
+    expect(failoverAttempts(true, 'CLOUD-API.LIVEKIT.IO')).toBe(FAILOVER_MAX_ATTEMPTS);
+  });
+
   it('does not fail over for non-cloud hosts', () => {
     expect(failoverAttempts(true, 'myproject.livekit.io')).toBe(1);
+    expect(failoverAttempts(true, 'cloud-api.example.com')).toBe(1);
     expect(failoverAttempts(true, 'example.com')).toBe(1);
     expect(failoverAttempts(true, '127.0.0.1')).toBe(1);
     expect(failoverAttempts(true, 'notlivekit.cloud')).toBe(1);

--- a/packages/livekit-server-sdk/src/failover.ts
+++ b/packages/livekit-server-sdk/src/failover.ts
@@ -21,8 +21,8 @@ export const MIN_FAILOVER_TIMEOUT_SECONDS = 5;
 
 /**
  * Total request attempts for a host; 1 means no failover. Failover only engages
- * when enabled, the host is a LiveKit Cloud domain, and the request timeout is
- * long enough to retry. `force` bypasses the cloud-host check (test-only).
+ * when enabled, the host is a LiveKit Cloud project or Cloud API domain, and the
+ * request timeout is long enough to retry. `force` bypasses the cloud-host check (test-only).
  */
 export function failoverAttempts(
   enabled: boolean,
@@ -30,7 +30,7 @@ export function failoverAttempts(
   force = false,
   timeoutSeconds = 0,
 ): number {
-  if (!enabled || !(force || isCloud(hostname))) {
+  if (!enabled || !(force || isCloud(hostname) || isCloudApi(hostname))) {
     return 1;
   }
   if (timeoutSeconds > 0 && timeoutSeconds < MIN_FAILOVER_TIMEOUT_SECONDS) {
@@ -42,6 +42,12 @@ export function failoverAttempts(
 // Failover only engages for LiveKit Cloud project domains.
 function isCloud(hostname: string): boolean {
   return hostname.endsWith('.livekit.cloud');
+}
+
+// The LiveKit Cloud API hosts: cloud-api.livekit.io and cloud-api.<env>.livekit.io.
+export function isCloudApi(hostname: string): boolean {
+  const host = hostname.toLowerCase();
+  return host.startsWith('cloud-api.') && host.endsWith('.livekit.io');
 }
 
 /** Normalizes a region URL to an http(s) scheme (ws -> http, wss -> https). */


### PR DESCRIPTION
## Why

A request to `cloud-api.livekit.io` was lost between Cloudflare and the origin on 2026-09-11: the edge acknowledged it, but no LiveKit system ever saw it, and the client waited out its full timeout. Every surrounding call succeeded, so a single retry would have recovered it.

The SDK's failover loop could not help, for two reasons:

- The attempts policy only matches `*.livekit.cloud`, so a `cloud-api.livekit.io` request always got exactly one attempt.
- Even with failover engaged, the loop gives up as soon as no untried origin exists, which is always the case for cloud-api: it has a single origin and `/settings/regions` returns 404.

## What

Two commits, each test-first:

1. **Retry the same host when a retryable failure has no fallback origin.** When `pickNext` finds no untried origin, a retryable failure (a thrown fetch error or an HTTP 5xx) now re-sends the request to the same host instead of surfacing it. Transport errors and 5xx are treated alike: a transport error can also mean the server executed the request and only the response was lost, so distinguishing them buys no idempotency safety, and cross-region failover already retries 5xx. Every attempt carries the same `X-Livekit-Request-Id`, so the server can dedup a replay. Max attempts and backoff are unchanged; a 4xx is still terminal.
2. **Enable retries for the LiveKit Cloud API hosts.** A new `isCloudApi` check matches `cloud-api.livekit.io` and `cloud-api.<env>.livekit.io` (case-insensitively) and joins `isCloud` in the attempts policy. A Cloud API host has a single origin, so the retry loop never fetches `/settings/regions` for it and goes straight to the same-host retry; otherwise every failed attempt would also pay the discovery timeout. The existing `.livekit.cloud` check is unchanged.

Includes a patch changeset for `livekit-server-sdk`.

## Behavior change

For cloud-api calls with a request timeout at or above `MIN_FAILOVER_TIMEOUT_SECONDS` (5s, including the 10s default), a lost request or a 5xx now costs up to `FAILOVER_MAX_ATTEMPTS` (3) attempts with exponential backoff instead of failing after one. A truly dead or persistently erroring origin takes up to three times the per-attempt budget to surface. Requests with a shorter timeout keep getting a single attempt. For `.livekit.cloud` project hosts, the same-host retry only engages once every discovered region has been tried, so their behavior is unchanged in practice.

Mirrors livekit/server-sdk-go#1002.

## Testing

`pnpm exec vitest --environment node run` in `packages/livekit-server-sdk`: 8 files, 115 tests passing, including the `test/api` integration suite against a local `livekit/test-server` container (`LK_TEST_SERVER_URL`).

New tests, each confirmed failing before its implementation commit:

- `TwirpRPC.test.ts`: "without a fallback origin, a transport error retries the same host", "without a fallback origin, a 5xx retries the same host", and "a Cloud API host retries without consulting region discovery" (asserts zero `/settings/regions` fetches).
- `failover.test.ts`: `cloud-api.livekit.io`, `cloud-api.staging.livekit.io`, and `CLOUD-API.LIVEKIT.IO` get max attempts; `cloud-api.example.com` gets one.

`pnpm lint` and `prettier --check` are clean on the changed files (the 3 existing lint warnings are pre-existing and untouched).
